### PR TITLE
:wrench: updating from pilot run

### DIFF
--- a/tools/bwa_mem.cwl
+++ b/tools/bwa_mem.cwl
@@ -7,7 +7,8 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 5000
+    ramMin: 14000
+    coresMin: 16
 baseCommand: [java, -Xms5000m, -jar, /picard.jar]
 arguments:
   - position: 0
@@ -50,7 +51,7 @@ inputs:
     type: File
   indexed_reference_fasta:
     type: File
-    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
     ^.dict, .amb, .ann, .bwt, .pac, .sa]
 outputs:
   output:

--- a/tools/bwa_mem_32t.cwl
+++ b/tools/bwa_mem_32t.cwl
@@ -7,7 +7,8 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 5000
+    ramMin: 14000
+    coresMin: 32
 baseCommand: [java, -Xms5000m, -jar, /picard.jar]
 arguments:
   - position: 0
@@ -43,14 +44,14 @@ arguments:
       PROGRAM_GROUP_NAME='bwamem'
       PROGRAM_GROUP_VERSION='0.7.15-r1140'
       PROGRAM_GROUP_COMMAND_LINE='bwa mem -K 100000000 -p -v 3 -t 32 -Y $(inputs.indexed_reference_fasta.basename)'
-      ALIGNER_PROPER_PAIR_FLAGS=true UNMAP_CONTAMINANT_READS=true
+      ALIGNER_PROPER_PAIR_FLAGS=true UNMAP_CONTAMINANT_READS=false
       UNMAPPED_READ_STRATEGY=COPY_TO_TAG
 inputs:
   input_bam:
     type: File
   indexed_reference_fasta:
     type: File
-    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
     ^.dict, .amb, .ann, .bwt, .pac, .sa]
 outputs:
   output:

--- a/tools/expression_getbasename.cwl
+++ b/tools/expression_getbasename.cwl
@@ -1,0 +1,16 @@
+cwlVersion: v1.0
+class: ExpressionTool
+id: expression_getbasename.cwl
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  input_file:
+    type: File
+
+outputs:
+  file_basename:
+    type: string
+
+expression:
+  "${return {file_basename: inputs.input_file.nameroot};}"  

--- a/tools/gatk_applybqsr.cwl
+++ b/tools/gatk_applybqsr.cwl
@@ -7,13 +7,13 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.beta.1'
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 4500
 baseCommand: [/gatk-launch, ApplyBQSR]
 arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      --javaOptions "-Xms3000m -Xmx8000m
+      --javaOptions "-Xms3000m
       -XX:+PrintFlagsFinal
       -XX:+PrintGCTimeStamps
       -XX:+PrintGCDateStamps

--- a/tools/gatk_baserecalibrator.cwl
+++ b/tools/gatk_baserecalibrator.cwl
@@ -13,7 +13,7 @@ arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --javaOptions "-Xms4000m -Xmx8000m
+      --javaOptions "-Xms4000m
       -XX:GCTimeLimit=50
       -XX:GCHeapFreeLimit=10
       -XX:+PrintFlagsFinal

--- a/tools/gatk_gatherbqsrreports.cwl
+++ b/tools/gatk_gatherbqsrreports.cwl
@@ -13,7 +13,7 @@ arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      --javaOptions "-Xms3000m -Xmx8000m"
+      --javaOptions "-Xms3000m"
       -O GatherBqsrReports.recal_data.csv
 inputs:
   input_brsq_reports:

--- a/tools/gatk_haplotypecaller.cwl
+++ b/tools/gatk_haplotypecaller.cwl
@@ -5,10 +5,10 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 15000
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:3.6-0-g89b7209'
-baseCommand: [/usr/bin/java, -Xms2000m, -Xmx8000m -jar, /GenomeAnalysisTK.jar]
+baseCommand: [/usr/bin/java, -Xms2000m, -jar, /GenomeAnalysisTK.jar]
 arguments:
   - position: 1
     shellQuote: false
@@ -18,7 +18,7 @@ arguments:
       -R $(inputs.reference.path)
       --interval_padding 500
       -L $(inputs.interval_list.path)
-      -o local.sharded.bam && java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx8000m
+      -o local.sharded.bam && java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xms8000m
       -jar /GenomeAnalysisTK.jar
       -T HaplotypeCaller
       -R $(inputs.reference.path)

--- a/tools/gatk_validategvcf.cwl
+++ b/tools/gatk_validategvcf.cwl
@@ -7,8 +7,8 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:3.6-0-g89b7209'
   - class: ResourceRequirement
-    ramMin: 8000
-baseCommand: [/usr/bin/java, -Xms2G, -jar, /GenomeAnalysisTK.jar]
+    ramMin: 4000
+baseCommand: [/usr/bin/java, -Xms2000m, -jar, /GenomeAnalysisTK.jar]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/gatk_validategvcf_xmx.cwl
+++ b/tools/gatk_validategvcf_xmx.cwl
@@ -1,0 +1,35 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: gatk_validategvcf
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/gatk:3.6-0-g89b7209'
+  - class: ResourceRequirement
+    ramMin: 4000
+baseCommand: [/usr/bin/java, -Xms2000m, -Xmx30000m, -jar, /GenomeAnalysisTK.jar]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      -T ValidateVariants
+      -V $(inputs.input_vcf.path)
+      -R $(inputs.reference.path)
+      -L $(inputs.wgs_calling_interval_list.path)
+      -gvcf
+      --validationTypeToExclude ALLELES
+      --dbsnp $(inputs.dbsnp_vcf.path)
+inputs:
+  input_vcf:
+    type: File
+    secondaryFiles: .tbi
+  reference:
+    type: File
+    secondaryFiles: [^.dict, .fai]
+  wgs_calling_interval_list:
+    type: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: .idx
+outputs: []

--- a/tools/picard_calculatereadgroupchecksum.cwl
+++ b/tools/picard_calculatereadgroupchecksum.cwl
@@ -7,8 +7,8 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.8.3'
   - class: ResourceRequirement
-    ramMin: 8000
-baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CalculateReadGroupChecksum]
+    ramMin: 4000
+baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CalculateReadGroupChecksum]
 arguments:
   - position: 1
     shellQuote: false
@@ -24,4 +24,4 @@ outputs:
   - id: output
     type: File
     outputBinding:
-      glob: '*_md5'
+      glob: '*.md5'

--- a/tools/picard_collectaggregationmetrics.cwl
+++ b/tools/picard_collectaggregationmetrics.cwl
@@ -7,8 +7,8 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard-r:picard2.8.3-r3.3.3'
   - class: ResourceRequirement
-    ramMin: 8000
-baseCommand: [ java, -Xms5000m, -Xmx8000m, -jar, /picard.jar, CollectMultipleMetrics]
+    ramMin: 10000
+baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_collectgvcfcallingmetrics.cwl
+++ b/tools/picard_collectgvcfcallingmetrics.cwl
@@ -5,10 +5,10 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 3000
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.8.3'
-baseCommand: [java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CollectVariantCallingMetrics]
+baseCommand: [java, -Xms2000m, -jar, /picard.jar, CollectVariantCallingMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_collectqualityyieldmetrics.cwl
+++ b/tools/picard_collectqualityyieldmetrics.cwl
@@ -8,7 +8,7 @@ requirements:
     dockerPull: 'kfdrc/picard:2.8.3'
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CollectQualityYieldMetrics]
+baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectQualityYieldMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_collectreadgroupbamqualitymetrics.cwl
+++ b/tools/picard_collectreadgroupbamqualitymetrics.cwl
@@ -8,7 +8,7 @@ requirements:
     dockerPull: 'kfdrc/picard-r:picard2.8.3-r3.3.3'
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [ java, -Xms5000m, -Xmx8000m, -jar, /picard.jar, CollectMultipleMetrics]
+baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+++ b/tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
@@ -8,7 +8,7 @@ requirements:
     dockerPull: 'kfdrc/picard-r:picard2.8.3-r3.3.3'
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [ java, -Xms5000m, -Xmx8000m, -jar, /picard.jar, CollectMultipleMetrics]
+baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_collectwgsmetrics.cwl
+++ b/tools/picard_collectwgsmetrics.cwl
@@ -5,10 +5,10 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 4500
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.15.0'
-baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CollectWgsMetrics]
+baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectWgsMetrics]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_gatherbamfiles.cwl
+++ b/tools/picard_gatherbamfiles.cwl
@@ -8,12 +8,12 @@ requirements:
     dockerPull: 'kfdrc/picard:2.8.3'
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, GatherBamFiles]
+baseCommand: [ java, -Xms2000m, -jar, /picard.jar, GatherBamFiles]
 arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      OUTPUT=$(inputs.output_bam_basename).bam
+      OUTPUT=$(inputs.output_bam_basename).kfdrc.bam
       CREATE_INDEX=true
       CREATE_MD5_FILE=true
 inputs:

--- a/tools/picard_markduplicates.cwl
+++ b/tools/picard_markduplicates.cwl
@@ -8,7 +8,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [java, -Dsamjdk.compression_level=2, -Xms4000m, -Xmx8000m, -jar, /picard.jar, MarkDuplicates]
+baseCommand: [java, -Dsamjdk.compression_level=2, -Xms4000m, -jar, /picard.jar, MarkDuplicates]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_markduplicates_optname.cwl
+++ b/tools/picard_markduplicates_optname.cwl
@@ -1,0 +1,44 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: picard_markduplicates
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/picard:2.8.3'
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 8000
+baseCommand: [java, -Dsamjdk.compression_level=2, -Xms4000m, -Xmx8000m, -jar, /picard.jar, MarkDuplicates]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      OUTPUT=${
+        if(inputs.base_file_name=="default"){
+          var names = inputs.input_bam.nameroot.split(".")
+          names.splice(-2)
+          return names.join(".")
+        }else{
+          return inputs.base_file_name
+        }
+      }.aligned.unsorted.duplicates_marked.bam
+      METRICS_FILE=metrics_filename
+      VALIDATION_STRINGENCY=SILENT
+      OPTICAL_DUPLICATE_PIXEL_DISTANCE=2500
+      ASSUME_SORT_ORDER=queryname
+inputs:
+  input_bams:
+    type:
+      type: array
+      items: File
+      inputBinding:
+        prefix: INPUT=
+        separate: false
+  base_file_name: 
+    type: string?
+    default: default
+outputs: 
+  output_markduplicates_bam:
+    type: File
+    outputBinding:
+      glob: '*.bam'

--- a/tools/picard_mergevcfs.cwl
+++ b/tools/picard_mergevcfs.cwl
@@ -5,10 +5,10 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 3000
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.8.3'
-baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, MergeVcfs]
+baseCommand: [ java, -Xms2000m, -jar, /picard.jar, MergeVcfs]
 arguments:
   - position: 1
     shellQuote: false

--- a/tools/picard_revertsam.cwl
+++ b/tools/picard_revertsam.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.8.3'
   - class: ShellCommandRequirement
-baseCommand: [java, -Xmx8000m, -jar, /picard.jar]
+baseCommand: [java, -Xms8000m, -jar, /picard.jar]
 arguments:
   - position: 0
     shellQuote: false

--- a/tools/picard_revertsam_inputcram.cwl
+++ b/tools/picard_revertsam_inputcram.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/picard:2.17.4'
   - class: ShellCommandRequirement
-baseCommand: [java, -Xmx8000m, -jar, /picard.jar]
+baseCommand: [java, -Xms8000m, -jar, /picard.jar]
 arguments:
   - position: 0
     shellQuote: false
@@ -14,6 +14,8 @@ arguments:
       REFERENCE_SEQUENCE=$(inputs.reference.path)
       INPUT=$(inputs.input_cram.path)
       OUTPUT=$(runtime.outdir)
+      OUTPUT_BY_READGROUP=true
+      OUTPUT_BY_READGROUP_FILE_FORMAT=bam
       SANITIZE=true
       MAX_DISCARD_FRACTION=0.005
       ATTRIBUTE_TO_CLEAR=XT
@@ -24,7 +26,6 @@ arguments:
       RESTORE_ORIGINAL_QUALITIES=true
       REMOVE_DUPLICATE_INFORMATION=true
       REMOVE_ALIGNMENT_INFORMATION=true
-      OUTPUT_BY_READGROUP=true
 inputs:
   input_cram:
     type: File

--- a/tools/picard_sortsam.cwl
+++ b/tools/picard_sortsam.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: ResourceRequirement
     ramMin: 8000
-baseCommand: [java, -Xmx4000m, -Xmx8000m, -jar, /picard.jar]
+baseCommand: [java, -Xms4000m, -jar, /picard.jar]
 arguments:
   - position: 0
     shellQuote: false

--- a/tools/samtools_covert_to_cram.cwl
+++ b/tools/samtools_covert_to_cram.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 8000
+    ramMin: 4000
   - class: DockerRequirement
     dockerPull: 'kfdrc/samtools:1.3.1'
 baseCommand: [samtools, view]

--- a/tools/verifybamid.cwl
+++ b/tools/verifybamid.cwl
@@ -8,6 +8,7 @@ requirements:
     dockerPull: 'kfdrc/verifybamid:1.0.1'
   - class: ResourceRequirement
     ramMin: 5000
+    coresMin: 4
 baseCommand: [VerifyBamID]
 arguments:
   - position: 1

--- a/workflows/cavatica/dev/hcpost-m2p2-15-src-rqd.cwl
+++ b/workflows/cavatica/dev/hcpost-m2p2-15-src-rqd.cwl
@@ -1,0 +1,130 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: m2.2xlarge
+  - class: sbg:maxNumberOfParallelInstances
+    value: 15
+inputs:
+  verifybamid_selfsm: File
+  picard_gatherbamfiles_output:
+    type: File
+    secondaryFiles: [^.bai]
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+outputs:
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+steps:
+  picard_collectaggregationmetrics:
+    run: ../tools_withsrc/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools_withsrc/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools_withsrc/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools_withsrc/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools_withsrc/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools_withsrc/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid_selfsm
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools_withsrc/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles_output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools_withsrc/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools_withsrc/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools_withsrc/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/hcpost-m2p2-src-rqd.cwl
+++ b/workflows/cavatica/dev/hcpost-m2p2-src-rqd.cwl
@@ -1,0 +1,128 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: m2.2xlarge
+inputs:
+  verifybamid_selfsm: File
+  picard_gatherbamfiles_output:
+    type: File
+    secondaryFiles: [^.bai]
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+outputs:
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+steps:
+  picard_collectaggregationmetrics:
+    run: ../tools_withsrc/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools_withsrc/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools_withsrc/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools_withsrc/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools_withsrc/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools_withsrc/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid_selfsm
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools_withsrc/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles_output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools_withsrc/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools_withsrc/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools_withsrc/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/kfdrc-alignment-cavatica-ubam.cwl
+++ b/workflows/cavatica/dev/kfdrc-alignment-cavatica-ubam.cwl
@@ -1,0 +1,277 @@
+cwlVersion: v1.0
+class: Workflow
+id: kfdrc-alignment-cavatica
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r4.8xlarge;ebs-gp2;1024
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2
+
+inputs:
+  input_bam: File
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: input_bam
+    out: [file_basename]
+
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_noco.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: getbasename/file_basename
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination_2.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf_xmx.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-m2p2-15.cwl
+++ b/workflows/cavatica/dev/workflow-m2p2-15.cwl
@@ -1,0 +1,271 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: m2.2xlarge
+  - class: sbg:maxNumberOfParallelInstances
+    value: 15
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-origin-bwa32t.cwl
+++ b/workflows/cavatica/dev/workflow-origin-bwa32t.cwl
@@ -1,0 +1,266 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-origin.cwl
+++ b/workflows/cavatica/dev/workflow-origin.cwl
@@ -1,0 +1,266 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-r3p8-2-bwa32t.cwl
+++ b/workflows/cavatica/dev/workflow-r3p8-2-bwa32t.cwl
@@ -1,0 +1,271 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_32t.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-r3p8-bwa32t-cram.cwl
+++ b/workflows/cavatica/dev/workflow-r3p8-bwa32t-cram.cwl
@@ -1,0 +1,270 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge
+
+inputs:
+  input_cram: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam_inputcram.cwl
+    in:
+      input_cram: input_cram
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_32t.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-r3p8-bwa32t.cwl
+++ b/workflows/cavatica/dev/workflow-r3p8-bwa32t.cwl
@@ -1,0 +1,269 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_32t.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-r3p8-hc30t.cwl
+++ b/workflows/cavatica/dev/workflow-r3p8-hc30t.cwl
@@ -1,0 +1,269 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools_30.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/dev/workflow-r3p8.cwl
+++ b/workflows/cavatica/dev/workflow-r3p8.cwl
@@ -1,0 +1,269 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge
+
+inputs:
+  input_bam: File
+  base_file_name: string
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: base_file_name
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: base_file_name
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: base_file_name
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: base_file_name
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: base_file_name
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
@@ -1,0 +1,277 @@
+cwlVersion: v1.0
+class: Workflow
+id: kfdrc_alignment_inputcram_cavatica
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r4.8xlarge;ebs-gp2;1024
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2
+
+inputs:
+  input_cram: File
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: input_cram
+    out: [file_basename]
+
+  picard_revertsam:
+    run: ../tools/picard_revertsam_inputcram.cwl
+    in:
+      input_cram: input_cram
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_noco.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: getbasename/file_basename
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination_2.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
@@ -1,0 +1,276 @@
+cwlVersion: v1.0
+class: Workflow
+id: kfdrc_alignment_pipeline_cavatica
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r4.8xlarge;ebs-gp2;1024
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2
+
+inputs:
+  input_bam: File
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites:
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.tbi]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: input_bam
+    out: [file_basename]
+
+  picard_revertsam:
+    run: ../tools/picard_revertsam.cwl
+    in:
+      input_bam: input_bam
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: getbasename/file_basename
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
@@ -1,0 +1,131 @@
+cwlVersion: v1.0
+class: Workflow
+id: scatter_haplotypecaller
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+  verifybamid_selfsm: File
+  picard_gatherbamfiles_output:
+    type: File
+    secondaryFiles: [^.bai]
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+outputs:
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: picard_gatherbamfiles_output
+    out: [file_basename]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles_output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination_2.cwl
+    in: 
+      verifybamid_selfsm: verifybamid_selfsm
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles_output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []

--- a/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
@@ -1,0 +1,151 @@
+cwlVersion: v1.0
+class: Workflow
+id: kf-postbqsr-cavatica
+requirements:
+  - class: ScatterFeatureRequirement
+hints:
+  - class: sbg:AWSInstanceType
+    value: r3.8xlarge;ebs-gp2;1024
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2
+
+inputs:
+  input_final_bam:
+    type: File
+    secondaryFiles: [^.bai]
+  indexed_reference_fasta:
+    type: File
+    secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .64.alt,
+    ^.dict, .amb, .ann, .bwt, .pac, .sa, .fai]
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf:
+    type: File
+    secondaryFiles: [.idx]
+
+outputs:
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: input_final_bam
+    out: [file_basename]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: input_final_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: input_final_bam
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: input_final_bam
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: input_final_bam
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: input_final_bam
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: input_final_bam
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination_2.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: input_final_bam
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+

--- a/workflows/kfdrc_alignment_inputcram.cwl
+++ b/workflows/kfdrc_alignment_inputcram.cwl
@@ -1,0 +1,263 @@
+cwlVersion: v1.0
+class: Workflow
+id: kfdrc_alignment_pipeline
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+  input_cram: File
+  indexed_reference_fasta: File
+  contamination_sites_ud: File
+  contamination_sites_mu: File
+  contamination_sites_bed: File
+  knownsites: File[]
+  sequence_grouping_tsv: File
+  wgs_coverage_interval_list: File
+  wgs_calling_interval_list: File
+  reference_dict: File
+  wgs_evaluation_interval_list: File
+  dbsnp_vcf: File
+
+outputs:
+  duplicates_marked_bam:
+    type: File
+    outputSource: picard_markduplicates/output_markduplicates_bam
+  sorted_bam:
+    type: File
+    outputSource: picard_sortsam/output_sorted_bam
+  bqsr_report:
+    type: File
+    outputSource: gatk_gatherbqsrreports/output
+  final_bam:
+    type: File
+    outputSource: picard_gatherbamfiles/output
+  gvcf:
+    type: File
+    outputSource: picard_mergevcfs/output
+  cram:
+    type: File
+    outputSource: samtools_coverttocram/output
+  verifybamid_output:
+    type: File
+    outputSource: verifybamid/output
+  collect_quality_yield_metrics:
+    type: File[]
+    outputSource: picard_collectqualityyieldmetrics/output
+  collect_unsortedreadgroup_bam_quality_metrics:
+    type: 
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output1
+  collect_unsortedreadgroup_bam_quality_metrics_pdf:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: picard_collectunsortedreadgroupbamqualitymetrics/output2
+  collect_collect_aggregation_metrics:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output1
+  collect_collect_aggregation_pdf:
+    type: File[]
+    outputSource: picard_collectaggregationmetrics/output2
+  collect_wgs_metrics:
+    type: File
+    outputSource: picard_collectwgsmetrics/output
+  calculate_readgroup_checksum:
+    type: File
+    outputSource: picard_calculatereadgroupchecksum/output
+  collect_readgroupbam_quality_metrics:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output1
+  collect_readgroupbam_quality_pdf:
+    type: File[]
+    outputSource: picard_collectreadgroupbamqualitymetrics/output2
+  picard_collect_gvcf_calling_metrics:
+    type: File[]
+    outputSource: picard_collectgvcfcallingmetrics/output
+
+steps:
+  getbasename:
+    run: ../tools/expression_getbasename.cwl
+    in:
+      input_file: input_cram
+    out: [file_basename]
+
+  picard_revertsam:
+    run: ../tools/picard_revertsam_inputcram.cwl
+    in:
+      input_cram: input_cram
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_collectqualityyieldmetrics:
+    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    in:
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  bwa_mem:
+    run: ../tools/bwa_mem_noco.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_bam: picard_revertsam/output
+    scatter: [input_bam]
+    out: [output]
+
+  picard_collectunsortedreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: bwa_mem/output
+    scatter: [input_bam]
+    out: [output1, output2]
+
+  picard_markduplicates:
+    run: ../tools/picard_markduplicates.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bams: bwa_mem/output
+    out: [output_markduplicates_bam]
+
+  picard_sortsam:
+    run: ../tools/picard_sortsam.cwl
+    in:
+      base_file_name: getbasename/file_basename
+      input_bam: picard_markduplicates/output_markduplicates_bam
+    out: [output_sorted_bam]
+
+  verifybamid:
+    run: ../tools/verifybamid.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      ref_fasta: indexed_reference_fasta
+      contamination_sites_ud: contamination_sites_ud
+      contamination_sites_mu: contamination_sites_mu
+      contamination_sites_bed: contamination_sites_bed
+    out: [output]
+
+  createsequencegrouping:
+    run: ../tools/expression_createsequencegrouping.cwl
+    in:
+      sequence_grouping_tsv: sequence_grouping_tsv
+    out: [sequence_grouping_array]
+
+  gatk_baserecalibrator:
+    run: ../tools/gatk_baserecalibrator.cwl
+    in:
+      input_bam: picard_sortsam/output_sorted_bam
+      knownsites: knownsites
+      reference: indexed_reference_fasta
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [output]
+
+  gatk_gatherbqsrreports:
+    run: ../tools/gatk_gatherbqsrreports.cwl
+    in:
+      input_brsq_reports: gatk_baserecalibrator/output
+    out: [output]
+
+  gatk_applybqsr:
+    run: ../tools/gatk_applybqsr.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_sortsam/output_sorted_bam
+      bqsr_report: gatk_gatherbqsrreports/output
+      sequence_interval: createsequencegrouping/sequence_grouping_array
+    scatter: [sequence_interval]
+    out: [recalibrated_bam]
+
+  picard_gatherbamfiles:
+    run: ../tools/picard_gatherbamfiles.cwl
+    in:
+      input_bam: gatk_applybqsr/recalibrated_bam
+      output_bam_basename: getbasename/file_basename
+    out: [output]
+
+  picard_collectaggregationmetrics:
+    run: ../tools/picard_collectaggregationmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectreadgroupbamqualitymetrics:
+    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output1, output2]
+
+  picard_collectwgsmetrics:
+    run: ../tools/picard_collectwgsmetrics.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+      intervals: wgs_coverage_interval_list
+    out: [output]
+
+  picard_calculatereadgroupchecksum:
+    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+    out: [output]
+
+  samtools_coverttocram:
+    run: ../tools/samtools_covert_to_cram.cwl
+    in:
+      input_bam: picard_gatherbamfiles/output
+      reference: indexed_reference_fasta
+    out: [output]
+
+  picard_intervallisttools:
+    run: ../tools/picard_intervallisttools.cwl
+    in:
+      interval_list: wgs_calling_interval_list
+    out: [output]
+
+  checkcontamination:
+    run: ../tools/expression_checkcontamination_2.cwl
+    in: 
+      verifybamid_selfsm: verifybamid/output
+    out: [contamination]
+
+  gatk_haplotypecaller:
+    run: ../tools/gatk_haplotypecaller.cwl
+    in:
+      reference: indexed_reference_fasta
+      input_bam: picard_gatherbamfiles/output
+      interval_list: picard_intervallisttools/output
+      contamination: checkcontamination/contamination
+    scatter: [interval_list]
+    out: [output]
+
+  picard_mergevcfs:
+    run: ../tools/picard_mergevcfs.cwl
+    in:
+      input_vcf: gatk_haplotypecaller/output
+      output_vcf_basename: getbasename/file_basename
+    out:
+      [output]
+
+  picard_collectgvcfcallingmetrics:
+    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference_dict: reference_dict
+      final_gvcf_base_name: getbasename/file_basename
+      dbsnp_vcf: dbsnp_vcf
+      wgs_evaluation_interval_list: wgs_evaluation_interval_list
+    out: [output]
+
+  gatk_validategvcf:
+    run: ../tools/gatk_validategvcf.cwl
+    in:
+      input_vcf: picard_mergevcfs/output
+      reference: indexed_reference_fasta
+      wgs_calling_interval_list: wgs_calling_interval_list
+      dbsnp_vcf: dbsnp_vcf
+    out: []


### PR DESCRIPTION
- tools:
  - add `class: ResourceRequirement` ramMin/coresMin under `requirements`
  - remove `-Xmx` & keep `-Xms` from `baseCommand`
  - fix bug of `picard_calculatereadgroupchecksum.cwl` to capture proper `md5` output
  - fix bug of `bwa_mem` to loading correct ALT contigs
  - add `expression_getbasename.cwl` to get basename from input file
  - add `-Xmx` in `gatk_validategvcf_xmx.cwl` to avoid `OutOfMemoryError`
  - add `picard_markduplicates_optname.cwl` where input `base_file_name` is optional
- workflow:
  - add workflows under `workflows/cavatica` as ones which are cavatica compatible
  - add `workflows/kfdrc_alignment_inputcram.cwl` which takes CRAM as input
  - update workflow id
  - remove required input `base_file_name`, pass `expression_getbasename.cwl` output to downstream tools