### PR TITLE
:wrench: update/add gatk35 & update checkcontam

### DIFF
--- a/tools/expression_checkcontamination.cwl
+++ b/tools/expression_checkcontamination.cwl
@@ -16,6 +16,10 @@ outputs:
 
 expression:
   "${
-      var contam = inputs.verifybamid_selfsm.contents.split('\\n')[2].split('\\t')[6];
-      return {contamination: contam/0.75};
+      var lines=inputs.verifybamid_selfsm.contents.split('\\n');
+      for (var i=1; i<lines.length; i++){
+        var fields=lines[i].split('\\t');
+        if (fields.length != 19) {continue;}
+        return {contamination: fields[6]/0.75};
+      }
   }"  

--- a/tools/gatk_haplotypecaller_35.cwl
+++ b/tools/gatk_haplotypecaller_35.cwl
@@ -1,0 +1,49 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: gatk_haplotypecaller
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 15000
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/gatk:4.beta.1-3.5'
+baseCommand: [/gatk-launch, --javaOptions, -Xms2000m]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      PrintReads
+      -I $(inputs.input_bam.path)
+      --interval_padding 500
+      -L $(inputs.interval_list.path)
+      -O local.sharded.bam && java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xms8000m
+      -jar /GenomeAnalysisTK.jar
+      -T HaplotypeCaller
+      -R $(inputs.reference.path)
+      -o $(inputs.input_bam.nameroot).vcf.gz
+      -I local.sharded.bam
+      -L $(inputs.interval_list.path)
+      -ERC GVCF
+      --max_alternate_alleles 3
+      -variant_index_parameter 128000
+      -variant_index_type LINEAR
+      -contamination $(inputs.contamination)
+      --read_filter OverclippedRead
+inputs:
+  reference:
+    type: File
+    secondaryFiles: [^.dict, .fai]
+  input_bam:
+    type: File
+    secondaryFiles: [^.bai]
+  interval_list:
+    type: File
+  contamination:
+    type: float
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: '*.vcf.gz'
+    secondaryFiles: [.tbi]

--- a/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
@@ -240,7 +240,7 @@ steps:
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller.cwl
+    run: ../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles/output

--- a/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_inputcram_cavatica.cwl
@@ -95,27 +95,27 @@ outputs:
 
 steps:
   getbasename:
-    run: ../tools/expression_getbasename.cwl
+    run: ../../tools/expression_getbasename.cwl
     in:
       input_file: input_cram
     out: [file_basename]
 
   picard_revertsam:
-    run: ../tools/picard_revertsam_inputcram.cwl
+    run: ../../tools/picard_revertsam_inputcram.cwl
     in:
       input_cram: input_cram
       reference: indexed_reference_fasta
     out: [output]
 
   picard_collectqualityyieldmetrics:
-    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    run: ../../tools/picard_collectqualityyieldmetrics.cwl
     in:
       input_bam: picard_revertsam/output
     scatter: [input_bam]
     out: [output]
 
   bwa_mem:
-    run: ../tools/bwa_mem_noco.cwl
+    run: ../../tools/bwa_mem_noco.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
       input_bam: picard_revertsam/output
@@ -123,28 +123,28 @@ steps:
     out: [output]
 
   picard_collectunsortedreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
     in:
       input_bam: bwa_mem/output
     scatter: [input_bam]
     out: [output1, output2]
 
   picard_markduplicates:
-    run: ../tools/picard_markduplicates.cwl
+    run: ../../tools/picard_markduplicates.cwl
     in:
       base_file_name: getbasename/file_basename
       input_bams: bwa_mem/output
     out: [output_markduplicates_bam]
 
   picard_sortsam:
-    run: ../tools/picard_sortsam.cwl
+    run: ../../tools/picard_sortsam.cwl
     in:
       base_file_name: getbasename/file_basename
       input_bam: picard_markduplicates/output_markduplicates_bam
     out: [output_sorted_bam]
 
   verifybamid:
-    run: ../tools/verifybamid.cwl
+    run: ../../tools/verifybamid.cwl
     in:
       input_bam: picard_sortsam/output_sorted_bam
       ref_fasta: indexed_reference_fasta
@@ -154,13 +154,13 @@ steps:
     out: [output]
 
   createsequencegrouping:
-    run: ../tools/expression_createsequencegrouping.cwl
+    run: ../../tools/expression_createsequencegrouping.cwl
     in:
       sequence_grouping_tsv: sequence_grouping_tsv
     out: [sequence_grouping_array]
 
   gatk_baserecalibrator:
-    run: ../tools/gatk_baserecalibrator.cwl
+    run: ../../tools/gatk_baserecalibrator.cwl
     in:
       input_bam: picard_sortsam/output_sorted_bam
       knownsites: knownsites
@@ -170,13 +170,13 @@ steps:
     out: [output]
 
   gatk_gatherbqsrreports:
-    run: ../tools/gatk_gatherbqsrreports.cwl
+    run: ../../tools/gatk_gatherbqsrreports.cwl
     in:
       input_brsq_reports: gatk_baserecalibrator/output
     out: [output]
 
   gatk_applybqsr:
-    run: ../tools/gatk_applybqsr.cwl
+    run: ../../tools/gatk_applybqsr.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_sortsam/output_sorted_bam
@@ -186,28 +186,28 @@ steps:
     out: [recalibrated_bam]
 
   picard_gatherbamfiles:
-    run: ../tools/picard_gatherbamfiles.cwl
+    run: ../../tools/picard_gatherbamfiles.cwl
     in:
       input_bam: gatk_applybqsr/recalibrated_bam
       output_bam_basename: getbasename/file_basename
     out: [output]
 
   picard_collectaggregationmetrics:
-    run: ../tools/picard_collectaggregationmetrics.cwl
+    run: ../../tools/picard_collectaggregationmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectreadgroupbamqualitymetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectwgsmetrics:
-    run: ../tools/picard_collectwgsmetrics.cwl
+    run: ../../tools/picard_collectwgsmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
@@ -215,32 +215,32 @@ steps:
     out: [output]
 
   picard_calculatereadgroupchecksum:
-    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    run: ../../tools/picard_calculatereadgroupchecksum.cwl
     in:
       input_bam: picard_gatherbamfiles/output
     out: [output]
 
   samtools_coverttocram:
-    run: ../tools/samtools_covert_to_cram.cwl
+    run: ../../tools/samtools_covert_to_cram.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output]
 
   picard_intervallisttools:
-    run: ../tools/picard_intervallisttools.cwl
+    run: ../../tools/picard_intervallisttools.cwl
     in:
       interval_list: wgs_calling_interval_list
     out: [output]
 
   checkcontamination:
-    run: ../tools/expression_checkcontamination_2.cwl
+    run: ../../tools/expression_checkcontamination_2.cwl
     in: 
       verifybamid_selfsm: verifybamid/output
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller_35.cwl
+    run: ../../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles/output
@@ -250,7 +250,7 @@ steps:
     out: [output]
 
   picard_mergevcfs:
-    run: ../tools/picard_mergevcfs.cwl
+    run: ../../tools/picard_mergevcfs.cwl
     in:
       input_vcf: gatk_haplotypecaller/output
       output_vcf_basename: getbasename/file_basename
@@ -258,7 +258,7 @@ steps:
       [output]
 
   picard_collectgvcfcallingmetrics:
-    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    run: ../../tools/picard_collectgvcfcallingmetrics.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference_dict: reference_dict
@@ -268,7 +268,7 @@ steps:
     out: [output]
 
   gatk_validategvcf:
-    run: ../tools/gatk_validategvcf.cwl
+    run: ../../tools/gatk_validategvcf.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference: indexed_reference_fasta

--- a/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
@@ -95,26 +95,26 @@ outputs:
 
 steps:
   getbasename:
-    run: ../tools/expression_getbasename.cwl
+    run: ../../tools/expression_getbasename.cwl
     in:
       input_file: input_bam
     out: [file_basename]
 
   picard_revertsam:
-    run: ../tools/picard_revertsam.cwl
+    run: ../../tools/picard_revertsam.cwl
     in:
       input_bam: input_bam
     out: [output]
 
   picard_collectqualityyieldmetrics:
-    run: ../tools/picard_collectqualityyieldmetrics.cwl
+    run: ../../tools/picard_collectqualityyieldmetrics.cwl
     in:
       input_bam: picard_revertsam/output
     scatter: [input_bam]
     out: [output]
 
   bwa_mem:
-    run: ../tools/bwa_mem.cwl
+    run: ../../tools/bwa_mem.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
       input_bam: picard_revertsam/output
@@ -122,28 +122,28 @@ steps:
     out: [output]
 
   picard_collectunsortedreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
     in:
       input_bam: bwa_mem/output
     scatter: [input_bam]
     out: [output1, output2]
 
   picard_markduplicates:
-    run: ../tools/picard_markduplicates.cwl
+    run: ../../tools/picard_markduplicates.cwl
     in:
       base_file_name: getbasename/file_basename
       input_bams: bwa_mem/output
     out: [output_markduplicates_bam]
 
   picard_sortsam:
-    run: ../tools/picard_sortsam.cwl
+    run: ../../tools/picard_sortsam.cwl
     in:
       base_file_name: getbasename/file_basename
       input_bam: picard_markduplicates/output_markduplicates_bam
     out: [output_sorted_bam]
 
   verifybamid:
-    run: ../tools/verifybamid.cwl
+    run: ../../tools/verifybamid.cwl
     in:
       input_bam: picard_sortsam/output_sorted_bam
       ref_fasta: indexed_reference_fasta
@@ -153,13 +153,13 @@ steps:
     out: [output]
 
   createsequencegrouping:
-    run: ../tools/expression_createsequencegrouping.cwl
+    run: ../../tools/expression_createsequencegrouping.cwl
     in:
       sequence_grouping_tsv: sequence_grouping_tsv
     out: [sequence_grouping_array]
 
   gatk_baserecalibrator:
-    run: ../tools/gatk_baserecalibrator.cwl
+    run: ../../tools/gatk_baserecalibrator.cwl
     in:
       input_bam: picard_sortsam/output_sorted_bam
       knownsites: knownsites
@@ -169,13 +169,13 @@ steps:
     out: [output]
 
   gatk_gatherbqsrreports:
-    run: ../tools/gatk_gatherbqsrreports.cwl
+    run: ../../tools/gatk_gatherbqsrreports.cwl
     in:
       input_brsq_reports: gatk_baserecalibrator/output
     out: [output]
 
   gatk_applybqsr:
-    run: ../tools/gatk_applybqsr.cwl
+    run: ../../tools/gatk_applybqsr.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_sortsam/output_sorted_bam
@@ -185,28 +185,28 @@ steps:
     out: [recalibrated_bam]
 
   picard_gatherbamfiles:
-    run: ../tools/picard_gatherbamfiles.cwl
+    run: ../../tools/picard_gatherbamfiles.cwl
     in:
       input_bam: gatk_applybqsr/recalibrated_bam
       output_bam_basename: getbasename/file_basename
     out: [output]
 
   picard_collectaggregationmetrics:
-    run: ../tools/picard_collectaggregationmetrics.cwl
+    run: ../../tools/picard_collectaggregationmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectreadgroupbamqualitymetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectwgsmetrics:
-    run: ../tools/picard_collectwgsmetrics.cwl
+    run: ../../tools/picard_collectwgsmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
@@ -214,32 +214,32 @@ steps:
     out: [output]
 
   picard_calculatereadgroupchecksum:
-    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    run: ../../tools/picard_calculatereadgroupchecksum.cwl
     in:
       input_bam: picard_gatherbamfiles/output
     out: [output]
 
   samtools_coverttocram:
-    run: ../tools/samtools_covert_to_cram.cwl
+    run: ../../tools/samtools_covert_to_cram.cwl
     in:
       input_bam: picard_gatherbamfiles/output
       reference: indexed_reference_fasta
     out: [output]
 
   picard_intervallisttools:
-    run: ../tools/picard_intervallisttools.cwl
+    run: ../../tools/picard_intervallisttools.cwl
     in:
       interval_list: wgs_calling_interval_list
     out: [output]
 
   checkcontamination:
-    run: ../tools/expression_checkcontamination.cwl
+    run: ../../tools/expression_checkcontamination.cwl
     in: 
       verifybamid_selfsm: verifybamid/output
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller_35.cwl
+    run: ../../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles/output
@@ -249,7 +249,7 @@ steps:
     out: [output]
 
   picard_mergevcfs:
-    run: ../tools/picard_mergevcfs.cwl
+    run: ../../tools/picard_mergevcfs.cwl
     in:
       input_vcf: gatk_haplotypecaller/output
       output_vcf_basename: getbasename/file_basename
@@ -257,7 +257,7 @@ steps:
       [output]
 
   picard_collectgvcfcallingmetrics:
-    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    run: ../../tools/picard_collectgvcfcallingmetrics.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference_dict: reference_dict
@@ -267,7 +267,7 @@ steps:
     out: [output]
 
   gatk_validategvcf:
-    run: ../tools/gatk_validategvcf.cwl
+    run: ../../tools/gatk_validategvcf.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference: indexed_reference_fasta

--- a/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_alignment_pipeline_cavatica.cwl
@@ -239,7 +239,7 @@ steps:
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller.cwl
+    run: ../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles/output

--- a/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
@@ -94,7 +94,7 @@ steps:
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller.cwl
+    run: ../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles_output

--- a/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_haplotypecaller_cavatica.cwl
@@ -47,27 +47,27 @@ outputs:
     outputSource: picard_collectgvcfcallingmetrics/output
 steps:
   getbasename:
-    run: ../tools/expression_getbasename.cwl
+    run: ../../tools/expression_getbasename.cwl
     in:
       input_file: picard_gatherbamfiles_output
     out: [file_basename]
 
   picard_collectaggregationmetrics:
-    run: ../tools/picard_collectaggregationmetrics.cwl
+    run: ../../tools/picard_collectaggregationmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles_output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectreadgroupbamqualitymetrics.cwl
     in:
       input_bam: picard_gatherbamfiles_output
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectwgsmetrics:
-    run: ../tools/picard_collectwgsmetrics.cwl
+    run: ../../tools/picard_collectwgsmetrics.cwl
     in:
       input_bam: picard_gatherbamfiles_output
       reference: indexed_reference_fasta
@@ -75,26 +75,26 @@ steps:
     out: [output]
 
   samtools_coverttocram:
-    run: ../tools/samtools_covert_to_cram.cwl
+    run: ../../tools/samtools_covert_to_cram.cwl
     in:
       input_bam: picard_gatherbamfiles_output
       reference: indexed_reference_fasta
     out: [output]
 
   picard_intervallisttools:
-    run: ../tools/picard_intervallisttools.cwl
+    run: ../../tools/picard_intervallisttools.cwl
     in:
       interval_list: wgs_calling_interval_list
     out: [output]
 
   checkcontamination:
-    run: ../tools/expression_checkcontamination_2.cwl
+    run: ../../tools/expression_checkcontamination_2.cwl
     in: 
       verifybamid_selfsm: verifybamid_selfsm
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller_35.cwl
+    run: ../../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: picard_gatherbamfiles_output
@@ -104,7 +104,7 @@ steps:
     out: [output]
 
   picard_mergevcfs:
-    run: ../tools/picard_mergevcfs.cwl
+    run: ../../tools/picard_mergevcfs.cwl
     in:
       input_vcf: gatk_haplotypecaller/output
       output_vcf_basename: getbasename/file_basename
@@ -112,7 +112,7 @@ steps:
       [output]
 
   picard_collectgvcfcallingmetrics:
-    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    run: ../../tools/picard_collectgvcfcallingmetrics.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference_dict: reference_dict
@@ -122,7 +122,7 @@ steps:
     out: [output]
 
   gatk_validategvcf:
-    run: ../tools/gatk_validategvcf.cwl
+    run: ../../tools/gatk_validategvcf.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference: indexed_reference_fasta

--- a/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
@@ -122,7 +122,7 @@ steps:
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller.cwl
+    run: ../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: input_final_bam

--- a/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
+++ b/workflows/cavatica/kfdrc_postbqsr_cavatica.cwl
@@ -59,13 +59,13 @@ outputs:
 
 steps:
   getbasename:
-    run: ../tools/expression_getbasename.cwl
+    run: ../../tools/expression_getbasename.cwl
     in:
       input_file: input_final_bam
     out: [file_basename]
 
   verifybamid:
-    run: ../tools/verifybamid.cwl
+    run: ../../tools/verifybamid.cwl
     in:
       input_bam: input_final_bam
       ref_fasta: indexed_reference_fasta
@@ -75,21 +75,21 @@ steps:
     out: [output]
 
   picard_collectaggregationmetrics:
-    run: ../tools/picard_collectaggregationmetrics.cwl
+    run: ../../tools/picard_collectaggregationmetrics.cwl
     in:
       input_bam: input_final_bam
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectreadgroupbamqualitymetrics:
-    run: ../tools/picard_collectreadgroupbamqualitymetrics.cwl
+    run: ../../tools/picard_collectreadgroupbamqualitymetrics.cwl
     in:
       input_bam: input_final_bam
       reference: indexed_reference_fasta
     out: [output1, output2]
 
   picard_collectwgsmetrics:
-    run: ../tools/picard_collectwgsmetrics.cwl
+    run: ../../tools/picard_collectwgsmetrics.cwl
     in:
       input_bam: input_final_bam
       reference: indexed_reference_fasta
@@ -97,32 +97,32 @@ steps:
     out: [output]
 
   picard_calculatereadgroupchecksum:
-    run: ../tools/picard_calculatereadgroupchecksum.cwl
+    run: ../../tools/picard_calculatereadgroupchecksum.cwl
     in:
       input_bam: input_final_bam
     out: [output]
 
   samtools_coverttocram:
-    run: ../tools/samtools_covert_to_cram.cwl
+    run: ../../tools/samtools_covert_to_cram.cwl
     in:
       input_bam: input_final_bam
       reference: indexed_reference_fasta
     out: [output]
 
   picard_intervallisttools:
-    run: ../tools/picard_intervallisttools.cwl
+    run: ../../tools/picard_intervallisttools.cwl
     in:
       interval_list: wgs_calling_interval_list
     out: [output]
 
   checkcontamination:
-    run: ../tools/expression_checkcontamination_2.cwl
+    run: ../../tools/expression_checkcontamination_2.cwl
     in: 
       verifybamid_selfsm: verifybamid/output
     out: [contamination]
 
   gatk_haplotypecaller:
-    run: ../tools/gatk_haplotypecaller_35.cwl
+    run: ../../tools/gatk_haplotypecaller_35.cwl
     in:
       reference: indexed_reference_fasta
       input_bam: input_final_bam
@@ -132,7 +132,7 @@ steps:
     out: [output]
 
   picard_mergevcfs:
-    run: ../tools/picard_mergevcfs.cwl
+    run: ../../tools/picard_mergevcfs.cwl
     in:
       input_vcf: gatk_haplotypecaller/output
       output_vcf_basename: getbasename/file_basename
@@ -140,7 +140,7 @@ steps:
       [output]
 
   picard_collectgvcfcallingmetrics:
-    run: ../tools/picard_collectgvcfcallingmetrics.cwl
+    run: ../../tools/picard_collectgvcfcallingmetrics.cwl
     in:
       input_vcf: picard_mergevcfs/output
       reference_dict: reference_dict


### PR DESCRIPTION
- add tool with gatk3.5 for haplotypecaller. 
- update `expression_checkcontamination.cwl` to cover different `@RG SM` situation
  - If BWA `SM` tag is not presented or presented at the last column in the header `@RG`, `VerifyBamID` will generate weird results which will cause problem for input for `gatk_haplotypecaller`. 
- update workflow relative path of tools

@zhangb1 @dmiller15 @kmhernan  please review, comment