### PR TITLE
🔧 pass thru merge with only one bam

### DIFF
--- a/tools/sambamba_merge_anylist.cwl
+++ b/tools/sambamba_merge_anylist.cwl
@@ -18,16 +18,19 @@ arguments:
   - position: 0
     shellQuote: false
     valueFrom: |-
-      bams="${
+      ${
         var flatin = [].concat.apply([],inputs.bams);
         var arr = [];
         for (var i=0; i<flatin.length; i++)
           arr = arr.concat(flatin[i].path)
-        return(arr.join(' '))
-      }"
-      /opt/sambamba_0.6.3/sambamba_v0.6.3 merge -t 36 $(inputs.base_file_name).aligned.duplicates_marked.unsorted.bam $bams && rm $bams
+        if (arr.length > 1) {
+          return "/opt/sambamba_0.6.3/sambamba_v0.6.3 merge -t 36 " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam " + arr.join(' ')
+        } else {
+          return "cp " + arr.join(' ') + " " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam"
+        }
+      }
 inputs:
   bams: { type: 'Any[]', doc: "Input will be a combination of File[] and deeply nested File[]. Any[] is flexible enough to accomodate the different types" }
   base_file_name: { type: string, doc: "String to be used in naming the output bam" }
 outputs:
-  merged_bam: { type: File, outputBinding: { glob: '*.bam' }, secondaryFiles: [.bai, ^.bai], format: BAM }
+  merged_bam: { type: File, outputBinding: { glob: '*.bam' }, format: BAM }


### PR DESCRIPTION
## Description

Encountered a bug when running a very small BAM through the new alignment pipeline. The merge step would fail because sambamba merge requires more than one BAM file for the tool to run. We do not view single bams as errors and want to have them continue on the pipeline. Therefore, we need to allow single bams to pass this step.

Resolves: https://github.com/d3b-center/bixu-tracker/issues/662

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tool passes cwltool validation
- [x] Successfully passing single bam merges on Cavatica: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/f1e56f3c-0c70-4fc6-a9fc-024f28d0d619/

**Test Configuration**:
* Environment: cwltool 3.0.20200324120055, Cavatica
* Test files: See Cavatica run

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings