### PR TITLE
🔧 no escapes in arguments

### DIFF
--- a/tools/python_createsequencegroups.cwl
+++ b/tools/python_createsequencegroups.cwl
@@ -19,7 +19,7 @@ arguments:
               longest_sequence = 0
               for line in ref_dict_file:
                   if line.startswith("@SQ"):
-                      line_split = line.split("\t")
+                      line_split = line.split(chr(9))
                       sequence_tuple_list.append((line_split[1].split("SN:")[1], int(line_split[2].split("LN:")[1])))
               longest_sequence = sorted(sequence_tuple_list, key=lambda x: x[1], reverse=True)[0][1]
           hg38_protection_tag = ":1+"
@@ -29,7 +29,7 @@ arguments:
           for sequence_tuple in sequence_tuple_list[1:]:
               if temp_size + sequence_tuple[1] <= longest_sequence:
                   temp_size += sequence_tuple[1]
-                  tsv_string += "\n" + sequence_tuple[0] + hg38_protection_tag
+                  tsv_string += chr(10) + sequence_tuple[0] + hg38_protection_tag
               else:
                   i += 1
                   pad = "{:0>2d}".format(i)


### PR DESCRIPTION
## Description

Issue brought to our attention by the IPC folks where escape characters were not being properly resolved in cwltool. This PR addresses the issue by changing tabs and newlines to their ASCII codes (chr(9) for tab and chr(10) for newline). 

Resolves https://github.com/d3b-center/bixu-tracker/issues/659

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tool passes cwltool validation
- [x] Locally tested cwltool
- [x] ASCII tab tested here: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/a27f4722-61d8-4df6-81d2-d85a50e9c665/


**Test Configuration**:
* Environment: cwltool 3.0.20200324120055 and Cavatica
* Test files: Reference dict in cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
