### PR TITLE
✨ set T flag for bwa

### DIFF
--- a/subworkflows/kfdrc_process_bam.cwl
+++ b/subworkflows/kfdrc_process_bam.cwl
@@ -10,6 +10,7 @@ inputs:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  min_alignment_score: int?
 outputs:
   unsorted_bams:
     type:
@@ -33,5 +34,6 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
       input_rgbam: samtools_split/bam_files
+      min_alignment_score: min_alignment_score
     scatter: [input_rgbam]
     out: [unsorted_bams] #+1 Nesting File[][]

--- a/subworkflows/kfdrc_process_bamlist.cwl
+++ b/subworkflows/kfdrc_process_bamlist.cwl
@@ -12,6 +12,7 @@ inputs:
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
   conditional_run: int
+  min_alignment_score: int?
 outputs:
   unsorted_bams:
     type:
@@ -30,6 +31,7 @@ steps:
       input_bam: input_bam_list 
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
+      min_alignment_score: min_alignment_score
     scatter: input_bam
     out: [unsorted_bams] #+2 Nesting File[][][]
 

--- a/subworkflows/kfdrc_process_pe_readslist2.cwl
+++ b/subworkflows/kfdrc_process_pe_readslist2.cwl
@@ -13,6 +13,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
+  min_alignment_score: int?
 outputs:
   unsorted_bams: 
     type:
@@ -30,6 +31,7 @@ steps:
       input_pe_reads: input_pe_reads_list
       input_pe_mates: input_pe_mates_list
       input_pe_rgs: input_pe_rgs_list
+      min_alignment_score: min_alignment_score
     scatter: [input_pe_reads, input_pe_mates, input_pe_rgs]
     scatterMethod: dotproduct
     out: [unsorted_bams]

--- a/subworkflows/kfdrc_process_pe_set.cwl
+++ b/subworkflows/kfdrc_process_pe_set.cwl
@@ -12,6 +12,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict'] 
+  min_alignment_score: int?
 outputs:
   unsorted_bams: 
     type: File[]
@@ -43,6 +44,7 @@ steps:
       reads: zcat_split_reads/output
       mates: zcat_split_mates/output
       rg: input_pe_rgs
+      min_alignment_score: min_alignment_score
     scatter: [reads, mates]
     scatterMethod: dotproduct
     out: [output] #+0 Nesting File[]

--- a/subworkflows/kfdrc_process_se_readslist2.cwl
+++ b/subworkflows/kfdrc_process_se_readslist2.cwl
@@ -12,6 +12,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
+  min_alignment_score: int?
 outputs:
   unsorted_bams: 
     type:
@@ -28,6 +29,7 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       input_se_reads: input_se_reads_list
       input_se_rgs: input_se_rgs_list
+      min_alignment_score: min_alignment_score
     scatter: [input_se_reads, input_se_rgs]
     scatterMethod: dotproduct
     out: [unsorted_bams]

--- a/subworkflows/kfdrc_process_se_set.cwl
+++ b/subworkflows/kfdrc_process_se_set.cwl
@@ -11,6 +11,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
+  min_alignment_score: int?
 outputs:
   unsorted_bams: 
     type: File[]
@@ -32,6 +33,7 @@ steps:
       ref: indexed_reference_fasta
       reads: zcat_split_reads/output
       rg: input_se_rgs
+      min_alignment_score: min_alignment_score
     scatter: reads
     out: [output] #+0 Nesting File[]
 

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -9,6 +9,7 @@ inputs:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  min_alignment_score: int?
 outputs:
   unsorted_bams:
     type: File[]
@@ -30,6 +31,7 @@ steps:
       interleaved:
         default: true
       rg: bamtofastq_chomp/rg_string 
+      min_alignment_score: min_alignment_score
     scatter: [reads]
     out: [output]
 

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -23,7 +23,7 @@ arguments:
     valueFrom: >-
       set -eo pipefail
       
-      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36 -T 0
+      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36 $(inputs.min_alignment_score ? '-T ' + inputs.min_alignment_score : '') 
       -Y $(inputs.ref.path)
       -R '${return inputs.rg}'
       ${return inputs.reads.path}
@@ -38,6 +38,7 @@ inputs:
   mates: { type: 'File?', doc: "Mates file for the reads" }
   interleaved: { type: boolean, default: false, doc: "The reads input is interleaved" }
   rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\\t')" }
+  min_alignment_score: { type: 'int?', doc: "Don't output alignment with score lower than INT. This option only affects output." }
 
 outputs:
   output: { type: File, outputBinding: { glob: '*.bam' } }

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -23,7 +23,8 @@ arguments:
     valueFrom: >-
       set -eo pipefail
       
-      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36 $(inputs.min_alignment_score ? '-T ' + inputs.min_alignment_score : '') 
+      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36
+      ${if (inputs.min_alignment_score == null) { return '';} else {return '-T ' + inputs.min_alignment_score;}}
       -Y $(inputs.ref.path)
       -R '${return inputs.rg}'
       ${return inputs.reads.path}

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -23,7 +23,7 @@ arguments:
     valueFrom: >-
       set -eo pipefail
       
-      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36
+      bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36 -T 0
       -Y $(inputs.ref.path)
       -R '${return inputs.rg}'
       ${return inputs.reads.path}

--- a/workflows/kfdrc_alignment_wf_cyoa.cwl
+++ b/workflows/kfdrc_alignment_wf_cyoa.cwl
@@ -87,6 +87,7 @@ inputs:
   run_wgs_metrics: { type: boolean, doc: "WgsMetrics will be collected. Only recommended for WGS inputs. Requires: wgs_coverage_interval_list" }
   run_agg_metrics: { type: boolean, doc: "AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics, QualityScoreDistribution, and SequencingArtifactMetrics will be collected. Recommended for both WXS and WGS inputs." }
   run_gvcf_processing: { type: boolean, doc: "gVCF will be generated. Requires: dbsnp_vcf, contamination_sites_bed, contamination_sites_mu, contamination_sites_ud, wgs_calling_interval_list, wgs_evaluation_interval_list" }
+  min_alignment_score: { type: 'int?', default: 0, doc: "For BWA MEM, Don't output alignment with score lower than INT. This option only affects output." }
 
 outputs:
   cram: {type: File, outputSource: samtools_bam_to_cram/output}
@@ -130,6 +131,7 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: biospecimen_name
       conditional_run: gatekeeper/scatter_bams
+      min_alignment_score: min_alignment_score
     scatter: conditional_run
     out: [unsorted_bams] #+2 Nesting File[][][]
 
@@ -141,6 +143,7 @@ steps:
       input_pe_mates_list: input_pe_mates_list
       input_pe_rgs_list: input_pe_rgs_list
       conditional_run: gatekeeper/scatter_pe_reads
+      min_alignment_score: min_alignment_score
     scatter: conditional_run
     out: [unsorted_bams] #+0 Nesting File[]
 
@@ -151,6 +154,7 @@ steps:
       input_se_reads_list: input_se_reads_list
       input_se_rgs_list: input_se_rgs_list
       conditional_run: gatekeeper/scatter_se_reads
+      min_alignment_score: min_alignment_score
     scatter: conditional_run
     out: [unsorted_bams] #+0 Nesting File[]
 

--- a/workflows/kfdrc_alignment_wf_cyoa.cwl
+++ b/workflows/kfdrc_alignment_wf_cyoa.cwl
@@ -87,7 +87,7 @@ inputs:
   run_wgs_metrics: { type: boolean, doc: "WgsMetrics will be collected. Only recommended for WGS inputs. Requires: wgs_coverage_interval_list" }
   run_agg_metrics: { type: boolean, doc: "AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics, QualityScoreDistribution, and SequencingArtifactMetrics will be collected. Recommended for both WXS and WGS inputs." }
   run_gvcf_processing: { type: boolean, doc: "gVCF will be generated. Requires: dbsnp_vcf, contamination_sites_bed, contamination_sites_mu, contamination_sites_ud, wgs_calling_interval_list, wgs_evaluation_interval_list" }
-  min_alignment_score: { type: 'int?', default: 0, doc: "For BWA MEM, Don't output alignment with score lower than INT. This option only affects output." }
+  min_alignment_score: { type: 'int?', default: 30, doc: "For BWA MEM, Don't output alignment with score lower than INT. This option only affects output." }
 
 outputs:
   cram: {type: File, outputSource: samtools_bam_to_cram/output}


### PR DESCRIPTION
## Description

Per https://github.com/d3b-center/bixu-tracker/issues/681, this adds the -T flag with a zero value such that reads in = reads out. No filtering may occur.

Resolves: https://github.com/d3b-center/bixu-tracker/issues/681

Ticket changed specs to want OPS to be able to set this flag at the top level. Updated PR to make the value an input and carry that input through the various subworkflows out into the main workflow.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tool passes cwltool validation
- [x] 30 T test https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/edf53932-21f8-4a21-8bef-ca213e0fc2e0/
- [x] 0 T test https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/6afb9e5c-0207-4bea-a96a-54866bace825/
- [x] Null T test https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/226d1f2a-6b16-4372-a6f8-38c37f389869/#
- [x] 30 T BAM+PE FASTQ Retest https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/1f933efe-a484-4d55-8ba6-5c6a51f7ce0b/
- [x] 0 T BAM+PE FASTQ Retest https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/9359cf44-5f83-4a16-a1e7-689d7200c462/
- [x] 30 T Single FASTQ https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/62fae4bb-648d-45b8-a928-83233b6d60f9/
- [x] 0 T Single FASTQ https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/ed5b0230-f761-428d-bdab-3b965ebecd21/

**Test Configuration**:
* Environment: cwltool 3.0.20200324120055
* Test files: See Cavatica tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
