### PR TITLE
🇪🇸 cwltool compatibility

### DIFF
--- a/tools/bundle_secondaryfiles.cwl
+++ b/tools/bundle_secondaryfiles.cwl
@@ -9,14 +9,14 @@ requirements:
   - class: ResourceRequirement
   - class: ShellCommandRequirement
   - class: InitialWorkDirRequirement
-    listing: [$(inputs.primary_file),$(inputs.secondary_files)]
+    listing: [$(inputs.primary_file)]
 baseCommand: [echo]
 inputs:
   primary_file: { type: File, doc: "Primary File" }
   secondary_files: { type: 'File[]', doc: "List of secondary files" }
 outputs:
-  output: 
+  output:
     type: File
     outputBinding:
       glob: $(inputs.primary_file.basename)
-    secondaryFiles: ${var arr = []; for (i = 0; i < inputs.secondary_files.length; i++) { if (inputs.secondary_files[i]) { arr.push(inputs.secondary_files[i].basename) } }; return arr}
+    secondaryFiles: $(inputs.secondary_files)

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -25,8 +25,10 @@ arguments:
       
       bwa mem -K 100000000 ${if (inputs.interleaved) {return '-p';} else {return ""}} -v 3 -t 36
       ${if (inputs.min_alignment_score == null) { return '';} else {return '-T ' + inputs.min_alignment_score;}}
-      -Y $(inputs.ref.path)
-      -R '${return inputs.rg}'
+      -Y $(inputs.ref.path) -R
+  - position: 2
+    shellQuote: false
+    valueFrom: >-
       ${return inputs.reads.path}
       ${if (inputs.mates != null) {return inputs.mates.path} else {return ""}}
       | /opt/samblaster/samblaster -i /dev/stdin -o /dev/stdout
@@ -38,8 +40,8 @@ inputs:
   reads: { type: File, doc: "Primary reads file" }
   mates: { type: 'File?', doc: "Mates file for the reads" }
   interleaved: { type: boolean, default: false, doc: "The reads input is interleaved" }
-  rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\\t')" }
   min_alignment_score: { type: 'int?', doc: "Don't output alignment with score lower than INT. This option only affects output." }
+  rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\t')", inputBinding: {position: 1} }
 
 outputs:
   output: { type: File, outputBinding: { glob: '*.bam' } }

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -34,7 +34,7 @@ arguments:
       | /opt/sambamba_0.6.3/sambamba_v0.6.3 sort -t 36 --natural-sort -m 15GiB --tmpdir ./
       -o ${if (inputs.reads != null) {return inputs.reads.nameroot} else {return ""}}.unsorted.bam -l 5 /dev/stdin
 inputs:
-  ref: { type: File, secondaryFiles: [^.dict, .64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, .fai], doc: "Reference fasta file with associated indexes" }
+  ref: { type: File, secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, ^.dict, .fai], doc: "Reference fasta file with associated indexes" }
   reads: { type: File, doc: "Primary reads file" }
   mates: { type: 'File?', doc: "Mates file for the reads" }
   interleaved: { type: boolean, default: false, doc: "The reads input is interleaved" }

--- a/tools/picard_gatherbamfiles.cwl
+++ b/tools/picard_gatherbamfiles.cwl
@@ -37,8 +37,6 @@ arguments:
       INPUT=$input_bams
       CREATE_INDEX=true
       CREATE_MD5_FILE=true
-      &&
-      rm $rm_bams
 inputs:
   input_bam: { type: 'File[]', secondaryFiles: [^.bai], doc: "Input bam file list" }
   output_bam_basename: { type: string, doc: "String to be used as the base filename for the output." }

--- a/tools/sambamba_merge_anylist.cwl
+++ b/tools/sambamba_merge_anylist.cwl
@@ -13,20 +13,35 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'images.sbgenomics.com/bogdang/sambamba:0.6.3'
   - class: InlineJavascriptRequirement
+    expressionLib:
+      - |-
+        //https://stackoverflow.com/a/27267762
+        var flatten = function flatten(ary) {
+            var ret = [];
+            for(var i = 0; i < ary.length; i++) {
+                if(Array.isArray(ary[i])) {
+                    ret = ret.concat(flatten(ary[i]));
+                } else {
+                    ret.push(ary[i]);
+                }
+            }
+            return ret;
+        }
 baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: |-
       ${
-        var flatin = [].concat.apply([],inputs.bams);
+        var flatin = flatten(inputs.bams);
         var arr = [];
-        for (var i=0; i<flatin.length; i++)
-          arr = arr.concat(flatin[i].path)
+        for (var i=0; i<flatin.length; i++) {
+          arr = arr.concat(flatin[i].path);
+        }
         if (arr.length > 1) {
-          return "/opt/sambamba_0.6.3/sambamba_v0.6.3 merge -t 36 " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam " + arr.join(' ')
+          return "/opt/sambamba_0.6.3/sambamba_v0.6.3 merge -t 36 " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam " + arr.join(' ');
         } else {
-          return "cp " + arr.join(' ') + " " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam"
+          return "cp " + arr.join(' ') + " " + inputs.base_file_name + ".aligned.duplicates_marked.unsorted.bam";
         }
       }
 inputs:

--- a/tools/untar_indexed_reference.cwl
+++ b/tools/untar_indexed_reference.cwl
@@ -1,0 +1,46 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: untar_indexed_reference
+baseCommand: [tar, xf]
+inputs:
+  reference_tar: 
+    type: File
+    inputBinding:
+      position: 1
+outputs:
+  fasta:
+    type: 'File'
+    outputBinding:
+      glob: '*.fasta' 
+  dict:
+    type: 'File'
+    outputBinding:
+      glob: '*.dict' 
+  fai:
+    type: 'File'
+    outputBinding:
+      glob: '*.fai' 
+  alt:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.alt'
+  amb:
+    type: 'File'
+    outputBinding:
+      glob: '*.64.amb' 
+  ann:
+    type: 'File'
+    outputBinding:
+      glob: '*.64.ann'
+  bwt:
+    type: 'File'
+    outputBinding:
+      glob: '*.64.bwt' 
+  pac:
+    type: 'File'
+    outputBinding:
+      glob: '*.64.pac' 
+  sa: 
+    type: 'File'
+    outputBinding:
+      glob: '*.64.sa' 

--- a/workflows/kfdrc_alignment_wf_cyoa.cwl
+++ b/workflows/kfdrc_alignment_wf_cyoa.cwl
@@ -131,7 +131,7 @@ outputs:
 
 steps:
   untar_reference:
-    run: ../subworkflows/untar_reference_tar.cwl
+    run: ../tools/untar_indexed_reference.cwl
     in:
       reference_tar: reference_tar
     out: [fasta,fai,dict,alt,amb,ann,bwt,pac,sa]

--- a/workflows/kfdrc_alignment_wf_cyoa.cwl
+++ b/workflows/kfdrc_alignment_wf_cyoa.cwl
@@ -232,7 +232,7 @@ steps:
     run: ../tools/gatk_baserecalibrator.cwl
     in:
       input_bam: sambamba_sort/sorted_bam
-      knownsites: knownsites
+      knownsites: index_knownsites/output
       reference: bundle_secondaries/output
       sequence_interval: python_createsequencegroups/sequence_intervals
     scatter: [sequence_interval]


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

These are changes necessary to allow our alignment workflow to run end-to-end using cwltool:
- Pulled out the rg_string value from the argument block. When left in the argument block, cwltool would not "interpret" the value. So if you hand it ('hello\\tworld') it would explicitly pass the double escaped tab ('\\t') rather than simply a tab ('\t'). The solution was to split the argument block into things that come before and after it then use inputBinding to put it between them.
- No longer rm bams in gatherbamfiles. The bams it tries to delete are typically readonly files in cwltool and users won't have rm permissions.
- Rewrote the flatten function in sambamba merge anylist. The old function was only flattening a single level so I rewrote it to recursively flatten. All other changes are just cleaning up the code in that tool.

Resolves https://github.com/d3b-center/bixu-tracker/issues/591

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the tool end to end using cwltool on my personal VM
- [x] IPC folks ran it as well and were satisfied with the results

**Test Configuration**:
* Environment: cwltool 3.0
* Test files: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/files/5ec6a6c3e4b0e4c51669012b/, https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/files/5ecd251be4b0e4c5b1fdfff1/, https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/files/5ecd251be4b0e4c5b1fdfff2/

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
