### PR TITLE
🐛 rg exptool for cavatica bug

### DIFF
--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -20,8 +20,15 @@ steps:
     run: ../tools/bamtofastq_chomp.cwl
     in:
       input_bam: input_rgbam
-      sample: sample_name
+#      sample: sample_name
     out: [output, rg_string]
+
+  expression_updatergsample:
+    run: ../tools/expression_preparerg.cwl
+    in:
+      rg: bamtofastq_chomp/rg_string
+      sample: sample_name
+    out: [rg_str]
 
   bwa_mem_naive_bam:
     run: ../tools/bwa_mem_naive.cwl
@@ -30,7 +37,8 @@ steps:
       reads: bamtofastq_chomp/output
       interleaved:
         default: true
-      rg: bamtofastq_chomp/rg_string 
+#      rg: bamtofastq_chomp/rg_string
+      rg: expression_updatergsample/rg_str
       min_alignment_score: min_alignment_score
     scatter: [reads]
     out: [output]

--- a/tools/bamtofastq_chomp.cwl
+++ b/tools/bamtofastq_chomp.cwl
@@ -34,21 +34,22 @@ arguments:
 inputs:
   input_bam: { type: File, doc: "Input bam file" }
   max_size: { type: long, default: 20000000000, doc: "The maximum size (in bytes) that an input bam can be before the FASTQ is split" }
-  sample: { type: string, doc: "String name of the sample used to relabel the rg string" }
+#  sample: { type: string, doc: "String name of the sample used to relabel the rg string" }
 outputs:
   output: { type: 'File[]', outputBinding: { glob: '*.fq' } }
   rg_string:
-    type: string
+#    type: string
+    type: File
     outputBinding:
       glob: rg.txt
-      loadContents: true
-      outputEval:
-        ${
-          var arr = self[0].contents.split('\n')[0].split('\t');
-          for (var i=1; i<arr.length; i++){
-            if (arr[i].startsWith('SM')){
-              arr[i] = 'SM:' + inputs.sample;
-            }
-          }
-          return arr.join('\\t');
-        }
+#      loadContents: true
+#      outputEval:
+#        ${
+#          var arr = self[0].contents.split('\n')[0].split('\t');
+#          for (var i=1; i<arr.length; i++){
+#            if (arr[i].startsWith('SM')){
+#              arr[i] = 'SM:' + inputs.sample;
+#            }
+#          }
+#          return arr.join('\\t');
+#        }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Replaces #100 

This PR attempts to address the problems arising with our alignment workflow in Cavatica. While there's nothing wrong with the existing code it appears some functionality of cwl cannot be reliably implemented in Cavatica for the time being. In this case, it's the outputEval of the tool bamtofastq_chomp.cwl. To temporarily get around this while SBG determines the cause, I have modified the pipeline to use the old preparerg expressiontool. This pipeline should be usable while SBG investigates the cause.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Cavatica: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/e3f2d951-ba70-4def-8570-115c59c6186e/; comparison run: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/3c2982cc-0c6b-44d5-9a9e-d903cc7aa985/
- [x] Tool passes cwltool validation

**Test Configuration**:
* Environment: Cavatica, cwltool 3.0.20200324120055
* Test files: See Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
