### PR TITLE
🐳 dockerPull from new registry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,6 @@ also be provided: `wxs_bait_interval_list` and `wxs_target_interval_list` for Hs
 
 
 ### Basic Info
-- tool images: https://hub.docker.com/r/kfdrc/
 - dockerfiles: https://github.com/d3b-center/bixtools
 - tested with
   - Seven Bridges Cavatica Platform: https://cavatica.sbgenomics.com/

--- a/tools/bamtofastq_chomp.cwl
+++ b/tools/bamtofastq_chomp.cwl
@@ -14,7 +14,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 1000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa-bundle:dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 arguments:

--- a/tools/biobambam2_bamsormadup.cwl
+++ b/tools/biobambam2_bamsormadup.cwl
@@ -6,7 +6,7 @@ requirements:
   - class: ResourceRequirement
     coresMin: 36
   - class: DockerRequirement
-    dockerPull: 'zhangb1/kf-bwa-bundle'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/kf-bwa-bundle'
   - class: InlineJavascriptRequirement
 baseCommand: [bamsormadup]
 arguments:

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -12,7 +12,7 @@ requirements:
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa:0.7.17-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa:0.7.17-dev'
   - class: InlineJavascriptRequirement
 baseCommand: []
 arguments:

--- a/tools/bwa_input_prepare.cwl
+++ b/tools/bwa_input_prepare.cwl
@@ -6,7 +6,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 1000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa-bundle:dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 arguments:

--- a/tools/bwa_mem.cwl
+++ b/tools/bwa_mem.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: bwa_mem
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa-picard:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-picard:latest-dev'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 50000
     coresMin: 36
   - class: DockerRequirement
-    dockerPull: 'zhangb1/bwa-kf-bundle:0.1.17'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-kf-bundle:0.1.17'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 doc: |-

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -41,7 +41,7 @@ inputs:
   mates: { type: 'File?', doc: "Mates file for the reads" }
   interleaved: { type: boolean, default: false, doc: "The reads input is interleaved" }
   min_alignment_score: { type: 'int?', doc: "Don't output alignment with score lower than INT. This option only affects output." }
-  rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\t')", inputBinding: {position: 1} }
+  rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\t')", inputBinding: {position: 1, shellQuote: true} }
 
 outputs:
   output: { type: File, outputBinding: { glob: '*.bam' } }

--- a/tools/bwa_mem_split_nodup.cwl
+++ b/tools/bwa_mem_split_nodup.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 14000
     coresMin: 16
   - class: DockerRequirement
-    dockerPull: 'zhangb1/kf-bwa-bundle'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/kf-bwa-bundle'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 arguments:

--- a/tools/fastq_chomp.cwl
+++ b/tools/fastq_chomp.cwl
@@ -12,7 +12,7 @@ requirements:
     ramMin: 8000
     coresMin: 4
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa-bundle:dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 arguments:

--- a/tools/gatk_applybqsr.cwl
+++ b/tools/gatk_applybqsr.cwl
@@ -9,7 +9,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
   - class: ResourceRequirement
     ramMin: 4500
 baseCommand: [/gatk, ApplyBQSR]

--- a/tools/gatk_baserecalibrator.cwl
+++ b/tools/gatk_baserecalibrator.cwl
@@ -9,7 +9,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [/gatk, BaseRecalibrator]

--- a/tools/gatk_baserecalibrator_3vcf.cwl
+++ b/tools/gatk_baserecalibrator_3vcf.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [/gatk, BaseRecalibrator]

--- a/tools/gatk_gatherbqsrreports.cwl
+++ b/tools/gatk_gatherbqsrreports.cwl
@@ -9,7 +9,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [/gatk, GatherBQSRReports]

--- a/tools/gatk_haplotypecaller.cwl
+++ b/tools/gatk_haplotypecaller.cwl
@@ -12,7 +12,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 10000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.beta.1-3.5'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.beta.1-3.5'
 baseCommand: [/gatk-launch, --javaOptions, -Xms2000m]
 arguments:
   - position: 1

--- a/tools/gatk_haplotypecaller_cram.cwl
+++ b/tools/gatk_haplotypecaller_cram.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 8000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
 baseCommand: [/gatk]
 arguments:
   - position: 1

--- a/tools/gatk_indexfeaturefile.cwl
+++ b/tools/gatk_indexfeaturefile.cwl
@@ -4,7 +4,7 @@ id: gatk_indexfeaturefile
 doc: "Creates an index for a feature file, e.g. VCF or BED file."
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/gatk_validategvcf.cwl
+++ b/tools/gatk_validategvcf.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.3.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.3.0'
   - class: ResourceRequirement
     ramMin: 30000
 baseCommand: [/gatk]

--- a/tools/picard_calculatereadgroupchecksum.cwl
+++ b/tools/picard_calculatereadgroupchecksum.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 4000
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CalculateReadGroupChecksum]

--- a/tools/picard_checkfingerprint.cwl
+++ b/tools/picard_checkfingerprint.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CheckFingerprint]

--- a/tools/picard_collectaggregationmetrics.cwl
+++ b/tools/picard_collectaggregationmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
   - class: ResourceRequirement
     ramMin: 12000
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]

--- a/tools/picard_collectaggregationmetrics_conditional.cwl
+++ b/tools/picard_collectaggregationmetrics_conditional.cwl
@@ -11,7 +11,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
   - class: ResourceRequirement
     ramMin: 12000
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]

--- a/tools/picard_collectalignmentsummarymetrics_conditional.cwl
+++ b/tools/picard_collectalignmentsummarymetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectAlignmentSummaryMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectgcbiasmetrics_conditional.cwl
+++ b/tools/picard_collectgcbiasmetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectGcBiasMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectgvcfcallingmetrics.cwl
+++ b/tools/picard_collectgvcfcallingmetrics.cwl
@@ -12,7 +12,7 @@ requirements:
     ramMin: 3000
     coresMin: 16
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [java, -Xms2000m, -jar, /picard.jar, CollectVariantCallingMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collecthsmetrics.cwl
+++ b/tools/picard_collecthsmetrics.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 8000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectHsMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collecthsmetrics_conditional.cwl
+++ b/tools/picard_collecthsmetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 8000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectHsMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectinsertsizemetrics_conditional.cwl
+++ b/tools/picard_collectinsertsizemetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectInsertSizeMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectqualityyieldmetrics.cwl
+++ b/tools/picard_collectqualityyieldmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectQualityYieldMetrics]

--- a/tools/picard_collectrawwgsmetrics.cwl
+++ b/tools/picard_collectrawwgsmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, CollectRawWgsMetrics]

--- a/tools/picard_collectreadgroupbamqualitymetrics.cwl
+++ b/tools/picard_collectreadgroupbamqualitymetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]

--- a/tools/picard_collectsequencingartifactmetrics_conditional.cwl
+++ b/tools/picard_collectsequencingartifactmetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectSequencingArtifactMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
+++ b/tools/picard_collectunsortedreadgroupbamqualitymetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, CollectMultipleMetrics]

--- a/tools/picard_collectwgsmetrics.cwl
+++ b/tools/picard_collectwgsmetrics.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 8000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, CollectWgsMetrics]
 arguments:
   - position: 1

--- a/tools/picard_collectwgsmetrics_conditional.cwl
+++ b/tools/picard_collectwgsmetrics_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 8000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [ java, -Xms2000m, -Xmx6000m, -XX:GCTimeLimit=50, -XX:GCHeapFreeLimit=10, -jar, /picard.jar, CollectWgsMetrics]
 arguments:
   - position: 1

--- a/tools/picard_createsequencedictionary.cwl
+++ b/tools/picard_createsequencedictionary.cwl
@@ -7,7 +7,7 @@ doc: |-
   The tool returnts the dict as its only output.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_dict)]
   - class: InlineJavascriptRequirement

--- a/tools/picard_gatherbamfiles.cwl
+++ b/tools/picard_gatherbamfiles.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: []

--- a/tools/picard_intervallisttools.cwl
+++ b/tools/picard_intervallisttools.cwl
@@ -9,7 +9,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [java, -Xmx2000m, -jar, /picard.jar]
 arguments:
   - position: 1

--- a/tools/picard_markduplicates.cwl
+++ b/tools/picard_markduplicates.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: picard_markduplicates
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/picard_markduplicates_single.cwl
+++ b/tools/picard_markduplicates_single.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: picard_markduplicates_single
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/picard_mergevcfs.cwl
+++ b/tools/picard_mergevcfs.cwl
@@ -11,7 +11,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 3000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [ java, -Xms2000m, -jar, /picard.jar, MergeVcfs]
 arguments:
   - position: 1

--- a/tools/picard_mergevcfs_python_renamesample.cwl
+++ b/tools/picard_mergevcfs_python_renamesample.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 3000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9'
 baseCommand: ["/bin/bash", "-c"]
 arguments:
   - position: 1

--- a/tools/picard_qualityscoredistribution_conditional.cwl
+++ b/tools/picard_qualityscoredistribution_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard-r:latest-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard-r:latest-dev'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, QualityScoreDistribution]
 arguments:
   - position: 1

--- a/tools/picard_renamesample.cwl
+++ b/tools/picard_renamesample.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
 baseCommand: [java, -Xmx2000m, -jar, /picard.jar]
 arguments:
   - position: 1

--- a/tools/picard_revertsam.cwl
+++ b/tools/picard_revertsam.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: picard_revertsam
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ShellCommandRequirement
 baseCommand: [java, -Xms8000m, -jar, /picard.jar]
 arguments:

--- a/tools/picard_samtofastq.cwl
+++ b/tools/picard_samtofastq.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: picard_samtofastq
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/picard_sortsam.cwl
+++ b/tools/picard_sortsam.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: picard_sortsam
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ShellCommandRequirement
   - class: ResourceRequirement
     ramMin: 8000

--- a/tools/picard_validatesamfile.cwl
+++ b/tools/picard_validatesamfile.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/picard:2.18.2-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.2-dev'
   - class: ResourceRequirement
     ramMin: 8000
 baseCommand: [ java, -Xms2000m, -Xmx8000m, -jar, /picard.jar, ValidateSamFile]

--- a/tools/python_createsequencegroups.cwl
+++ b/tools/python_createsequencegroups.cwl
@@ -6,7 +6,7 @@ doc: |-
   Intervals are determined by the longest SQ length in the dict.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/python:2.7.13'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/python:2.7.13'
   - class: InlineJavascriptRequirement
 baseCommand: [python, -c]
 arguments:

--- a/tools/sambamba_index.cwl
+++ b/tools/sambamba_index.cwl
@@ -6,7 +6,7 @@ requirements:
   - class: ResourceRequirement
     coresMin: 36
   - class: DockerRequirement
-    dockerPull: 'kfdrc/sambamba:v0.6.7-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/sambamba:v0.6.7-dev'
   - class: InitialWorkDirRequirement
     listing: []
   - class: InlineJavascriptRequirement

--- a/tools/samtools_bam_to_cram.cwl
+++ b/tools/samtools_bam_to_cram.cwl
@@ -12,7 +12,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 4000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.8-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev'
 baseCommand: [samtools, view]
 arguments:
   - position: 1

--- a/tools/samtools_bam_to_cram_dev.cwl
+++ b/tools/samtools_bam_to_cram_dev.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 4000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.8-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev'
 baseCommand: [samtools, view]
 arguments:
   - position: 1

--- a/tools/samtools_cram2bam.cwl
+++ b/tools/samtools_cram2bam.cwl
@@ -4,7 +4,7 @@ id: samtools_cram2bam
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.8-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev'
   - class: InlineJavascriptRequirement
 baseCommand: []
 arguments:

--- a/tools/samtools_cram_reheader.cwl
+++ b/tools/samtools_cram_reheader.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 4000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.8-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev'
 baseCommand: ["/bin/bash", "-c"]
 arguments:
   - position: 1

--- a/tools/samtools_cram_to_bam.cwl
+++ b/tools/samtools_cram_to_bam.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 4000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.8-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev'
 baseCommand: [samtools, view]
 arguments:
   - position: 1

--- a/tools/samtools_faidx.cwl
+++ b/tools/samtools_faidx.cwl
@@ -7,7 +7,7 @@ doc: |-
   Finally the tool will return the input reference file with the index (generated or provided) as a secondaryFile.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/samtools_split.cwl
+++ b/tools/samtools_split.cwl
@@ -11,7 +11,7 @@ doc: |-
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InlineJavascriptRequirement
 baseCommand: ["/bin/bash", "-c"]
 arguments:

--- a/tools/tabix_index.cwl
+++ b/tools/tabix_index.cwl
@@ -6,7 +6,7 @@ doc: >-
   The tool will output the input_file with the index, provided or created within, as a secondary file.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/verifybamid.cwl
+++ b/tools/verifybamid.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/verifybamid:1.0.2'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/verifybamid:1.0.2'
   - class: ResourceRequirement
     ramMin: 5000
     coresMin: 4

--- a/tools/verifybamid_contamination.cwl
+++ b/tools/verifybamid_contamination.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/verifybamid:1.0.2'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/verifybamid:1.0.2'
   - class: ResourceRequirement
     ramMin: 5000
     coresMin: 4

--- a/tools/verifybamid_contamination_conditional.cwl
+++ b/tools/verifybamid_contamination_conditional.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/verifybamid:1.0.2'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/verifybamid:1.0.2'
   - class: ResourceRequirement
     ramMin: 5000
     coresMin: 4

--- a/workflows/kfdrc-gatk-haplotypecaller-wf.cwl
+++ b/workflows/kfdrc-gatk-haplotypecaller-wf.cwl
@@ -211,5 +211,5 @@ sbg:categories:
 - HAPLOTYPECALLER
 - WGS
 sbg:links:
-- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.4.0'
+- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.5.0'
   label: github-release

--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -33,7 +33,6 @@ doc: |
   ![data service logo](https://github.com/d3b-center/d3b-research-workflows/raw/master/doc/kfdrc-logo-sm.png)
 
   ## Basic Info
-  - tool images: https://hub.docker.com/r/kfdrc/
   - dockerfiles: https://github.com/d3b-center/bixtools
   - tested with
     - Seven Bridges Cavatica Platform: https://cavatica.sbgenomics.com/
@@ -687,5 +686,5 @@ sbg:categories:
 - WXS
 - GVCF
 sbg:links:
-  - id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.3.1'
+  - id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.5.0'
     label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR updates the dockerPull statements to the new registry.
It also explicitly states shellquote for the rgstring in bwa-mem. This change counteracts an issue introduced by pushing with the new rabix composer.

Part of https://github.com/d3b-center/bixu-tracker/issues/846

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] WXS with Agg Metrics and gVCF creation: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/217ca7d6-d886-4257-8e13-df5dc11c847a/
- [x] HS Metrics pulls here but fails because we don't have the appropriate intervals: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/ce0437f5-4871-41ca-be2e-9735a0f7c37f/#
- [x] WGS BAM + WGS Metrics: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/f9cdea56-bbef-418d-8382-fed8d5d6b054/#
- [x] fastq_chomp is the only tool fastq processing not used in either of the above, so this test of the tool should cover FASTQ processing: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/92093e47-359a-42a1-acf7-37b3dc261837/#

**Test Configuration**:
* Environment: Cavatica
* Test files: see tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
