### PR TITLE
🚲 hc wf and alignemnt use same subwf

### DIFF
--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -656,6 +656,7 @@ steps:
   generate_gvcf:
     run: ../subworkflows/kfdrc_bam_to_gvcf.cwl
     in:
+      biospecimen_name: biospecimen_name
       contamination_sites_bed: contamination_sites_bed
       contamination_sites_mu: contamination_sites_mu
       contamination_sites_ud: contamination_sites_ud
@@ -686,5 +687,5 @@ sbg:categories:
 - WXS
 - GVCF
 sbg:links:
-  - id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.5.0'
+  - id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.6.0'
     label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Changes:
- BAM to gVCF subworkflow tools updated to what is run in the CRAM to gVCF standalone
- Alignment input to generate_gvcf step updated to fulfill new requirements
- CRAM to gVCF now uses same generate_gvcf subworkflow as alignment
- Iterate release
- Cleaned up some trailing whitespaces

Closes https://github.com/d3b-center/bixu-tracker/issues/822

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Old prod alignment: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/e4b6abd5-84d4-4f94-a13c-e2fbf4b27ccb/
- [x] New prod alignment: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/a955ae0d-bf9a-4144-a4b5-edd3d1d89abc/
- [x] Old cram to gvcf: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/75c1de20-1eeb-4f57-9c28-1f307a361ef0/
- [x] New cram to gvcf: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/7e33b701-3c76-4695-944e-4350c847b9e2/
- [x] Both pass cwltool validation

Checking the gvcf stats, old & new have identical stats indicating that nothing has been broken in the update.

**Test Configuration**:
* Environment: cwltool 3.0.20200807132242, Cavatica
* Test files: See Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
