### PR TITLE
🚚  sync alignment wf output names

### DIFF
--- a/tools/picard_collectalignmentsummarymetrics_conditional.cwl
+++ b/tools/picard_collectalignmentsummarymetrics_conditional.cwl
@@ -21,7 +21,7 @@ arguments:
     valueFrom: >-
       INPUT=$(inputs.input_bam.path)
       REFERENCE_SEQUENCE=$(inputs.reference.path)
-      OUTPUT=$(inputs.input_bam.nameroot).alignmentsummary_metrics
+      OUTPUT=$(inputs.input_bam.nameroot).alignment_summary_metrics
       METRIC_ACCUMULATION_LEVEL="null"
       METRIC_ACCUMULATION_LEVEL="SAMPLE"
       METRIC_ACCUMULATION_LEVEL="LIBRARY"
@@ -31,4 +31,4 @@ inputs:
   reference: { type: File, secondaryFiles: [.fai], doc: "Reference fasta with dict and fai indexes" }
   conditional_run: { type: int, doc: "Placeholder variable to allow conditional running" } 
 outputs:
-  output: { type: File, outputBinding: { glob: '*.alignmentsummary_metrics' } }
+  output: { type: File, outputBinding: { glob: '*.alignment_summary_metrics' } }

--- a/tools/picard_collectgcbiasmetrics_conditional.cwl
+++ b/tools/picard_collectgcbiasmetrics_conditional.cwl
@@ -22,7 +22,7 @@ arguments:
       INPUT=$(inputs.input_bam.path)
       REFERENCE_SEQUENCE=$(inputs.reference.path)
       OUTPUT=$(inputs.input_bam.nameroot).gc_bias_metrics.txt
-      SUMMARY_OUTPUT=$(inputs.input_bam.nameroot).summary_metrics.txt
+      SUMMARY_OUTPUT=$(inputs.input_bam.nameroot).gc_bias_summary_metrics.txt
       CHART_OUTPUT=$(inputs.input_bam.nameroot).gc_bias_metrics.pdf
       METRIC_ACCUMULATION_LEVEL="null"
       METRIC_ACCUMULATION_LEVEL="SAMPLE"

--- a/tools/sentieon_bqsr.cwl
+++ b/tools/sentieon_bqsr.cwl
@@ -121,7 +121,7 @@ outputs:
 - id: output_reads
   type: File
   outputBinding:
-    glob: "*.recalibrated.*am"
+    glob: "*.*am"
   secondaryFiles:
     - pattern: .bai
       required: false 
@@ -146,15 +146,15 @@ arguments:
         var ext = inputs.output_type
         if (ext === "BAM")
         {
-            var out_extension = ".recalibrated.bam"
+            var out_extension = ".bam"
         }
         else if (ext === "CRAM")
         {
-            var out_extension = ".recalibrated.cram"
+            var out_extension = ".cram"
         }
         else
         {
-            var out_extension = ".recalibrated".concat(inputs.input_bam.nameext.toLowerCase())
+            var out_extension = inputs.input_bam.nameext.toLowerCase()
         }
         if(inputs.prefix)
         {

--- a/tools/sentieon_run_agg_metrics.cwl
+++ b/tools/sentieon_run_agg_metrics.cwl
@@ -245,7 +245,7 @@ outputs:
 - id: as_output
   type: File
   outputBinding:
-    glob: '*.alignmentsummary_metrics'
+    glob: '*.alignment_summary_metrics'
 - id: sama_bait_bias_detail_metrics
   type: File
   outputBinding:
@@ -325,7 +325,7 @@ arguments:
     ${
         var AlignmentStat_opt = ""
         if (inputs.adapter_seq) AlignmentStat_opt = "--adapter_seq " + inputs.adapter_seq + " "
-        return "AlignmentStat " + AlignmentStat_opt + inputs.input_bam.nameroot + ".alignmentsummary_metrics"
+        return "AlignmentStat " + AlignmentStat_opt + inputs.input_bam.nameroot + ".alignment_summary_metrics"
     }
   shellQuote: false
 - prefix: '--algo'

--- a/tools/sentieon_run_agg_metrics.cwl
+++ b/tools/sentieon_run_agg_metrics.cwl
@@ -289,7 +289,7 @@ outputs:
 - id: is_metrics
   type: File
   outputBinding:
-    glob: '*.insert_size_metrics.txt'
+    glob: '*.insert_size_metrics'
 - id: is_plot
   type: File
   outputBinding:
@@ -389,7 +389,7 @@ arguments:
   shellQuote: false
 - prefix: '--algo'
   position: 80
-  valueFrom: InsertSizeMetricAlgo $(inputs.input_bam.nameroot).insert_size_metrics.txt
+  valueFrom: InsertSizeMetricAlgo $(inputs.input_bam.nameroot).insert_size_metrics
   shellQuote: false
 - prefix: ''
   position: 110
@@ -404,7 +404,7 @@ arguments:
 - prefix: ''
   position: 130
   valueFrom: |-
-    ; sentieon plot InsertSizeMetricAlgo -o $(inputs.input_bam.nameroot).insert_size_Histogram.pdf $(inputs.input_bam.nameroot).insert_size_metrics.txt
+    ; sentieon plot InsertSizeMetricAlgo -o $(inputs.input_bam.nameroot).insert_size_Histogram.pdf $(inputs.input_bam.nameroot).insert_size_metrics
   shellQuote: false
 - prefix: ''
   position: 140

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -369,6 +369,7 @@ steps:
       sentieon_license: sentieon_license
       reference: untar_reference/indexed_fasta
       input_bam: sentieon_markdups/out_alignments
+      prefix: output_basename
       known_sites: index_knownsites/output
     out: [output_reads, recal_table]
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR modifies the naming of the outputs in the Sentieon alignment workflow to match those produced by the GATK-based alignment workflow. One caveat:
- Changed the name of the summary metrics file produced by Picard GC Bias metrics. The updated name more clearly defines what is in the file and matches the output produced by Sentieon.
- Changed the name of AlignmentSummary metrics output. We have had it as `alignmentsummary_metrics` which is probably a typo as it doesn't match what GATK puts in their docs: https://gatk.broadinstitute.org/hc/en-us/articles/5358857328667-AlignmentSummaryMetrics. The output is now ".alignment_summary_metrics". We will have to update the docs to reflect this.

Closes https://github.com/d3b-center/bixu-tracker/issues/1512

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/d3b-bixu/ha-bam-benchmarking/tasks/00bd1757-2083-4c50-b5e0-a05eaca56a89/stats/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
