### PR TITLE
🐛  bamtofastq cpu port open

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ to `true`; no additonal inputs are required.
   run_sex_metrics: {type: boolean, doc: "idxstats will be collected and X/Y ratios calculated"}
   # ADVANCED
   min_alignment_score: { type: 'int?', default: 30, doc: "For BWA MEM, Don't output alignment with score lower than INT. This option only affects output." }
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
 ```
 
 ### Outputs:
@@ -355,6 +356,13 @@ Homo_sapiens_assembly38.fasta.fai
    failing or generating erroneous files.
 1. Turning off gVCF creation and metrics collection for a minimal successful run.
 1. Suggested reference inputs (available from the [Broad Resource Bundle](https://console.cloud.google.com/storage/browser/genomics-public-data/resources/broad/hg38/v0)):
+1. For large BAM inputs, users may encounter a scenario where jobs fail during
+   the bamtofastq step. The given error will recommend that users try increasing
+   disk space. Increasing the disk space will solve the error for all but the
+   largest inputs. For those extremely large inputs with many read groups that
+   continue to get this error, it is recommended that users increase the value for
+   `bamtofastq_cpu`. Increasing this value will decrease the number of concurrent
+   bamtofastq jobs that run on the same instance.
 ```yaml
 contamination_sites_bed: Homo_sapiens_assembly38.contam.bed
 contamination_sites_mu: Homo_sapiens_assembly38.contam.mu

--- a/subworkflows/kfdrc_process_bam.cwl
+++ b/subworkflows/kfdrc_process_bam.cwl
@@ -12,6 +12,7 @@ inputs:
   sample_name: string
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
 
 outputs:
   unsorted_bams:
@@ -40,5 +41,6 @@ steps:
       input_rgbam: samtools_split/bam_files
       min_alignment_score: min_alignment_score
       cram_reference: cram_reference
+      bamtofastq_cpu: bamtofastq_cpu
     scatter: [input_rgbam]
     out: [unsorted_bams] #+1 Nesting File[][]

--- a/subworkflows/kfdrc_process_bamlist.cwl
+++ b/subworkflows/kfdrc_process_bamlist.cwl
@@ -14,6 +14,7 @@ inputs:
   conditional_run: int
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
 
 outputs:
   unsorted_bams:
@@ -35,6 +36,7 @@ steps:
       sample_name: sample_name
       min_alignment_score: min_alignment_score
       cram_reference: cram_reference
+      bamtofastq_cpu: bamtofastq_cpu
     scatter: input_bam
     out: [unsorted_bams] #+2 Nesting File[][][]
 

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -11,6 +11,7 @@ inputs:
   sample_name: string
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
 
 outputs:
   unsorted_bams:
@@ -23,6 +24,7 @@ steps:
     in:
       input_align: input_rgbam
       reference: cram_reference
+      cpu: bamtofastq_cpu
     out: [output, rg_string]
 
   expression_updatergsample:

--- a/tools/bamtofastq_chomp.cwl
+++ b/tools/bamtofastq_chomp.cwl
@@ -12,7 +12,8 @@ doc: |-
 requirements:
   - class: ShellCommandRequirement
   - class: ResourceRequirement
-    ramMin: 1000
+    ramMin: $(inputs.ram * 1000)
+    coresMin: $(inputs.cpu)
   - class: DockerRequirement
     dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev'
   - class: InlineJavascriptRequirement
@@ -51,6 +52,8 @@ inputs:
   input_align: { type: File, doc: "Input alignment file" }
   max_size: { type: 'long?', default: 20000000000, doc: "The maximum size (in bytes) that an input bam can be before the FASTQ is split" }
   reference: { type: 'File?', doc: "Fasta file if input is cram", secondaryFiles: [.fai] }
+  cpu: { type: 'int?', default: 1, doc: "CPUs to allocate to this task." }
+  ram: { type: 'int?', default: 2, doc: "GB of RAM to allocate to this task." }
 
 outputs:
   output: { type: 'File[]', outputBinding: { glob: '*.fq' } }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Opens the port for bamtofastq_chomp step. This port allows some troubleshooting for extremely large, multi-readgroup BAM inputs where aggressive job stacking caused instances to run out of disk space.

Fixes https://github.com/d3b-center/bixu-tracker/issues/1432

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I guess this was already tested by Brian but I'll do a test when I can find a good BAM for it.

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have committed any related changes to the PR
