### PR TITLE
🐛  drop cram bai

### DIFF
--- a/tools/sentieon_ReadWriter.cwl
+++ b/tools/sentieon_ReadWriter.cwl
@@ -105,6 +105,9 @@ inputs:
   type: string
   inputBinding:
     position: 150
+- id: rm_cram_bai
+  doc: BAI files are generated for CRAM files. If you don't want them, set this option.
+  type: boolean?
 - id: cpu_per_job
   label: CPU per job
   doc: CPU per job
@@ -132,3 +135,7 @@ arguments:
 - prefix: --algo
   position: 100
   valueFrom: ReadWriter
+- position: 999
+  shellQuote: false
+  valueFrom: |
+    $(inputs.rm_cram_bai ? "&& rm *cram.bai" : "")

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -384,6 +384,8 @@ steps:
       output_file_name:
         source: sentieon_bqsr/output_reads
         valueFrom: $(self.nameroot+".cram")
+      rm_cram_bai:
+        valueFrom: $(1 == 1)
     out: [output_reads]
 
   sentieon_hsmetrics:

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -469,5 +469,5 @@ hints:
 - SENTIEON
 - GATK
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.8.1'
+- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.8.4'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Sentieon readwriter will make a CRAM.BAI file whenever it is outputting a CRAM file. The reason for this is that:
```
Both .crai and .bai are generated, although most of the other tools will only use .crai index. .bai index may 
contain some useful information that can be used by Sentieon and other tools`. 
```

Additionally reading the BAM spec shows:
```
BAM indexes are supported by using 4-byte integer pointers called landmarks that are stored in container
header. BAM index pointer is a 64-bit value with 48 bits reserved for the BAM block start position and 16 bits
reserved for the in-block offset. When used to index CRAM files, the first 48 bits are used to store the CRAM
container start position and the last 16 bits are used to store the index of the landmark in the landmark array
stored in container header. The landmark index can be used to access the appropriate slice.
The above indexing scheme treats CRAM slices as individual records in BAM file. This allows to apply BAM
indexing to CRAM files, however it introduces some overhead in seeking specific alignment start because all
preceding records in the slice must be read and discarded.
```

Nevertheless, we have no desire to keep these files for final output. To prevent them from being saved, I have added a flag that will precipitate the removal of these files. It is normally off so the default behavior of the tool is unchanged.

Ad hoc @zhangb1 requiest.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] See the output json here: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/af98e59a-7136-4b96-9353-b0ff0fa20d23/

**Test Configuration**:
* Environment: cwltool and cavatica
* Test files: See cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
