### PR TITLE
🐛  sentieon alignment cleanup

### DIFF
--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -97,7 +97,7 @@ steps:
         valueFrom: $(self.interleaved)
       min_alignment_score: min_alignment_score
       chunk_size:
-        valueFrom: $(10000000)
+        valueFrom: $(100000000)
       cpu_per_job: cpu_per_job
       mem_per_job: mem_per_job
     out: [output]

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -96,6 +96,8 @@ steps:
         source: bwa_payload
         valueFrom: $(self.interleaved)
       min_alignment_score: min_alignment_score
+      chunk_size:
+        valueFrom: $(10000000)
       cpu_per_job: cpu_per_job
       mem_per_job: mem_per_job
     out: [output]

--- a/tools/samtools_split.cwl
+++ b/tools/samtools_split.cwl
@@ -24,7 +24,7 @@ arguments:
       set -eo pipefail
       RG_NUM=`samtools view -H $(inputs.input_bam.path) | grep -c ^@RG`
       if [ $RG_NUM != 1 ]; then
-        samtools split -f '%!.bam' -@ $(inputs.cores) --reference $(inputs.reference.path) $(inputs.input_bam.path)
+        samtools split -f '%*_%#.bam' -@ $(inputs.cores) --reference $(inputs.reference.path) $(inputs.input_bam.path)
       fi
 inputs:
   input_bam: { type: File, doc: "Input bam file" }

--- a/tools/sentieon_collectvcmetrics.cwl
+++ b/tools/sentieon_collectvcmetrics.cwl
@@ -50,7 +50,7 @@ inputs:
   read_filter: { type: 'string?', inputBinding: { position: 2, prefix: "--read_filter"}, doc: "Read filter name and params" }
 
   # CollectVCMetrics Arguments
-  dbsnp: { type: 'File?', secondaryFiles: [{ pattern: '.tbi', required: false }], inputBinding: { position: 12, prefix: "--dbsnp"}, doc: "dbSNP file", "sbg:fileTypes": "VCF, VCF.GZ" }
+  dbsnp: { type: 'File?', secondaryFiles: [{ pattern: '.idx', required: false }, { pattern: '.tbi', required: false }], inputBinding: { position: 12, prefix: "--dbsnp"}, doc: "dbSNP file", "sbg:fileTypes": "VCF, VCF.GZ" }
   vcf: { type: 'File?', secondaryFiles: [{ pattern: '.tbi', required: false }], inputBinding: { position: 12, prefix: "--vcf"}, doc: "Input VCF file for analysis" }
 
   conditional: { type: 'boolean?', doc: "Hook to disable this tool when wrapped in a workflow" }

--- a/tools/sentieon_haplotyper.cwl
+++ b/tools/sentieon_haplotyper.cwl
@@ -58,7 +58,7 @@ inputs:
 
   # Haplotyper Arguments
   annotation: { type: 'string?', inputBinding: { position: 12, prefix: "--annotation"}, doc: "Annotations to include, or exclude using '!' prefix" }
-  dbsnp: { type: 'File?', secondaryFiles: [{ pattern: '.tbi', required: false }], inputBinding: { position: 12, prefix: "--dbsnp"}, doc: "dbSNP file", "sbg:fileTypes": "VCF, VCF.GZ" }
+  dbsnp: { type: 'File?', secondaryFiles: [{ pattern: '.idx', required: false }, { pattern: '.tbi', required: false }], inputBinding: { position: 12, prefix: "--dbsnp"}, doc: "dbSNP file", "sbg:fileTypes": "VCF, VCF.GZ" }
   call_conf: { type: 'int?', inputBinding: { position: 12, prefix: "--call_conf"}, doc: "Call confidence level (default: 30)" }
   emit_conf: { type: 'int?', inputBinding: { position: 12, prefix: "--emit_conf"}, doc: "Emit confidence level (default: 30)" }
   emit_mode: { type: 'string?', inputBinding: { position: 12, prefix: "--emit_mode"}, doc: "Emit mode: variant, confident, all or gvcf (default: variant)" }

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -337,25 +337,12 @@ steps:
         linkMerge: merge_flattened
         pickValue: all_non_null
     out: [realgn_bam, cutadapt_stats]
-  sentieon_readwriter_merge_bams:
-    run: ../tools/sentieon_ReadWriter.cwl
-    in:
-      sentieon_license: sentieon_license
-      reference: untar_reference/indexed_fasta
-      input_bam: sentieon_bwa_mem_payloads/realgn_bam
-      output_file_name:
-        source: output_basename
-        valueFrom: $(self).aligned.sorted.bam
-    out: [output_reads]
   sentieon_markdups:
     run: ../tools/sentieon_dedup.cwl
     in:
       sentieon_license: sentieon_license
       reference: untar_reference/indexed_fasta
-      in_alignments:
-        source: sentieon_readwriter_merge_bams/output_reads
-        valueFrom: |
-          $(self ? [self] : self)
+      in_alignments: sentieon_bwa_mem_payloads/realgn_bam
     out: [metrics_file, out_alignments]
   sentieon_bqsr:
     run: ../tools/sentieon_bqsr.cwl


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Some bug fixes and cleanup work resulting from our work with HudsonAlpha:
- Set the chunksize for BWA to match what we are doing in our alignment workflow
- Adjusted the samtools split output naming so it could survive read group names with `/` in them (samtools will treat those as part of an absolute path)
- Added more explicit secondaryFiles for Haplotyper and CollectVCMetrics
- Removed unnecessary bam merging step. Most Sentieon tools can merge on input, including markdups

Closes https://github.com/d3b-center/bixu-tracker/issues/2208

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/e301aa61-6f0f-466d-8087-eea60e6839e7/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
