### PR TITLE
✂️  add cutadapt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ to `true`; no additonal inputs are required.
   cram: {type: File, outputSource: samtools_bam_to_cram/output, doc: "(Re)Aligned Reads File"}
   gvcf: {type: 'File[]?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated from the realigned alignment file."}
   verifybamid_output: {type: 'File[]?', outputSource: generate_gvcf/verifybamid_output, doc: "Ouput from VerifyBamID that is used to calculate contamination."}
+  cutadapt_stats: { type: 'File[]?', outputSource: collect_cutadapt_stats/out_filelist, doc: "Stats from Cutadapt runs, if run. One or more per read group." }
   bqsr_report: {type: File, outputSource: gatk_gatherbqsrreports/output, doc: "Recalibration report from BQSR."}
   gvcf_calling_metrics: {type: ['null', {type: array, items: {type: array, items: File}}], outputSource: generate_gvcf/gvcf_calling_metrics, doc: "General metrics for gVCF calling quality."}
   hs_metrics: {type: 'File[]?', outputSource: picard_collecthsmetrics/output, doc: "Picard CollectHsMetrics metrics for the analysis of target-capture sequencing experiments."}

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,11 @@ to `true`; no additonal inputs are required.
   run_agg_metrics: { type: boolean, doc: "AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics, QualityScoreDistribution, and SequencingArtifactMetrics will be collected. Recommended for both WXS and WGS inputs." }
   run_sex_metrics: {type: boolean, doc: "idxstats will be collected and X/Y ratios calculated"}
   # ADVANCED
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: { type: 'int?', default: 30, doc: "For BWA MEM, Don't output alignment with score lower than INT. This option only affects output." }
   bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
 ```

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -24,6 +24,7 @@ inputs:
           type: string
         interleaved:
           type: boolean
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -64,6 +65,15 @@ steps:
         source: bwa_payload
         valueFrom: |
           $(self.mates_file != null ? "TRIMMED." + self.mates_file.basename : null)
+      outputname_stats:
+        source: [output_basename, bwa_payload]
+        valueFrom: |
+          ${
+            var basename = self[0];
+            var rg_id = self[1].rg_str.match(/ID:[A-Za-z0-9-_/]*?([A-Za-z0-9-_]*)\\t/);
+            var reads_name = self[1].reads_file.basename.replace(/.f(ast)?[aq](\.gz)?$/,"");
+            return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"),  reads_name, "cutadapt_stats.txt"].join('.');
+          }
     out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
 
   sentieon_bwa_mem:

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -24,25 +24,61 @@ inputs:
           type: string
         interleaved:
           type: boolean
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   cpu_per_job: { type: 'int?' }
   mem_per_job: { type: 'int?' }
 outputs:
   realgn_bam:
     type: File
     outputSource: sentieon_bwa_mem/output
+  cutadapt_stats: { type: 'File', outputSource: cutadapt/cutadapt_stats }
 
 steps:
+  cutadapt:
+    run: ../tools/cutadapt.cwl
+    when: |
+      $(inputs.r1_threeprime_adapter != null && (inputs.r2_threeprime_adapter != null || inputs.input_reads2.mates_file == null) && (inputs.r2_threeprime_adapter != null || !inputs.interleaved.interleaved))
+    in:
+      input_reads1:
+        source: bwa_payload
+        valueFrom: $(self.reads_file)
+      input_reads2:
+        source: bwa_payload
+        valueFrom: $(self.mates_file)
+      interleaved:
+        source: bwa_payload
+        valueFrom: $(self.interleaved)
+      r1_threeprime_adapter: cutadapt_r1_adapter
+      r2_threeprime_adapter: cutadapt_r2_adapter
+      minimum_length: cutadapt_min_len
+      quality_base: cutadapt_quality_base
+      quality_cutoff: cutadapt_quality_cutoff
+      outputname_reads1:
+        source: bwa_payload
+        valueFrom: TRIMMED.$(self.reads_file.basename)
+      outputname_reads2:
+        source: bwa_payload
+        valueFrom: |
+          $(self.mates_file != null ? "TRIMMED." + self.mates_file.basename : null)
+    out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
+
   sentieon_bwa_mem:
     run: ../tools/sentieon_bwa_sort.cwl
     in:
       sentieon_license: sentieon_license
       reference: indexed_reference_fasta
       reads_forward:
-        source: bwa_payload
-        valueFrom: $(self.reads_file)
+        source: [cutadapt/trimmed_output, bwa_payload]
+        valueFrom: |
+          $(self[0] != null ? self[0] : self[1].reads_file)
       reads_mate:
-        source: bwa_payload
-        valueFrom: $(self.mates_file)
+        source: [cutadapt/trimmed_paired_output, bwa_payload]
+        valueFrom: |
+          $(self[0] != null ? self[0] : self[1].mates_file)
       rg:
         source: bwa_payload
         valueFrom: $(self.rg_str)

--- a/subworkflows/kfdrc_process_bam.cwl
+++ b/subworkflows/kfdrc_process_bam.cwl
@@ -4,12 +4,14 @@ id: kfdrc_process_bam
 requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement
+  - class: InlineJavascriptRequirement
 inputs:
   input_bam: File
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -52,6 +54,7 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
       input_rgbam: samtools_split/bam_files
+      output_basename: output_basename
       cutadapt_r1_adapter: cutadapt_r1_adapter
       cutadapt_r2_adapter: cutadapt_r2_adapter
       cutadapt_min_len: cutadapt_min_len

--- a/subworkflows/kfdrc_process_bam.cwl
+++ b/subworkflows/kfdrc_process_bam.cwl
@@ -10,6 +10,11 @@ inputs:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
   bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
@@ -22,6 +27,14 @@ outputs:
         type: array
         items: File
     outputSource: realign_split_bam/unsorted_bams
+  cutadapt_stats:
+    type:
+      - 'null'
+      - type: array
+        items:
+          type: array
+          items: File
+    outputSource: realign_split_bam/cutadapt_stats
 
 steps:
   samtools_split:
@@ -39,8 +52,13 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
       input_rgbam: samtools_split/bam_files
+      cutadapt_r1_adapter: cutadapt_r1_adapter
+      cutadapt_r2_adapter: cutadapt_r2_adapter
+      cutadapt_min_len: cutadapt_min_len
+      cutadapt_quality_base: cutadapt_quality_base
+      cutadapt_quality_cutoff: cutadapt_quality_cutoff
       min_alignment_score: min_alignment_score
       cram_reference: cram_reference
       bamtofastq_cpu: bamtofastq_cpu
     scatter: [input_rgbam]
-    out: [unsorted_bams] #+1 Nesting File[][]
+    out: [unsorted_bams, cutadapt_stats] #+1 Nesting File[][]

--- a/subworkflows/kfdrc_process_bamlist.cwl
+++ b/subworkflows/kfdrc_process_bamlist.cwl
@@ -5,6 +5,7 @@ requirements:
   - class: ScatterFeatureRequirement
   - class: MultipleInputFeatureRequirement
   - class: SubworkflowFeatureRequirement
+  - class: InlineJavascriptRequirement
 inputs:
   input_bam_list: File[]
   indexed_reference_fasta:
@@ -12,6 +13,7 @@ inputs:
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
   sample_name: string
   conditional_run: int
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -49,6 +51,7 @@ steps:
       input_bam: input_bam_list 
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
+      output_basename: output_basename
       cutadapt_r1_adapter: cutadapt_r1_adapter
       cutadapt_r2_adapter: cutadapt_r2_adapter
       cutadapt_min_len: cutadapt_min_len

--- a/subworkflows/kfdrc_process_bamlist.cwl
+++ b/subworkflows/kfdrc_process_bamlist.cwl
@@ -12,6 +12,11 @@ inputs:
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
   sample_name: string
   conditional_run: int
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
   bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
@@ -26,6 +31,16 @@ outputs:
           type: array
           items: File
     outputSource: process_bams/unsorted_bams 
+  cutadapt_stats:
+    type:
+      - 'null'
+      - type: array
+        items:
+          type: array
+          items:
+            type: array
+            items: File
+    outputSource: process_bams/cutadapt_stats
 
 steps:
   process_bams:
@@ -34,11 +49,16 @@ steps:
       input_bam: input_bam_list 
       indexed_reference_fasta: indexed_reference_fasta
       sample_name: sample_name
+      cutadapt_r1_adapter: cutadapt_r1_adapter
+      cutadapt_r2_adapter: cutadapt_r2_adapter
+      cutadapt_min_len: cutadapt_min_len
+      cutadapt_quality_base: cutadapt_quality_base
+      cutadapt_quality_cutoff: cutadapt_quality_cutoff
       min_alignment_score: min_alignment_score
       cram_reference: cram_reference
       bamtofastq_cpu: bamtofastq_cpu
     scatter: input_bam
-    out: [unsorted_bams] #+2 Nesting File[][][]
+    out: [unsorted_bams, cutadapt_stats] #+2 Nesting File[][][]
 
 $namespaces:
   sbg: https://sevenbridges.com

--- a/subworkflows/kfdrc_process_pe_readslist2.cwl
+++ b/subworkflows/kfdrc_process_pe_readslist2.cwl
@@ -13,6 +13,11 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: int?
 outputs:
   unsorted_bams: 
@@ -21,7 +26,8 @@ outputs:
       items:
         type: array
         items: File 
-    outputSource: process_pe_set/unsorted_bams 
+    outputSource: process_pe_set/unsorted_bams
+  cutadapt_stats: { type: 'File[]?', outputSource: process_pe_set/cutadapt_stats }
 
 steps:
   process_pe_set:
@@ -31,10 +37,15 @@ steps:
       input_pe_reads: input_pe_reads_list
       input_pe_mates: input_pe_mates_list
       input_pe_rgs: input_pe_rgs_list
+      cutadapt_r1_adapter: cutadapt_r1_adapter
+      cutadapt_r2_adapter: cutadapt_r2_adapter
+      cutadapt_min_len: cutadapt_min_len
+      cutadapt_quality_base: cutadapt_quality_base
+      cutadapt_quality_cutoff: cutadapt_quality_cutoff
       min_alignment_score: min_alignment_score
     scatter: [input_pe_reads, input_pe_mates, input_pe_rgs]
     scatterMethod: dotproduct
-    out: [unsorted_bams]
+    out: [unsorted_bams, cutadapt_stats]
 
 $namespaces:
   sbg: https://sevenbridges.com

--- a/subworkflows/kfdrc_process_pe_readslist2.cwl
+++ b/subworkflows/kfdrc_process_pe_readslist2.cwl
@@ -13,6 +13,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -37,6 +38,7 @@ steps:
       input_pe_reads: input_pe_reads_list
       input_pe_mates: input_pe_mates_list
       input_pe_rgs: input_pe_rgs_list
+      output_basename: output_basename
       cutadapt_r1_adapter: cutadapt_r1_adapter
       cutadapt_r2_adapter: cutadapt_r2_adapter
       cutadapt_min_len: cutadapt_min_len

--- a/subworkflows/kfdrc_process_pe_set.cwl
+++ b/subworkflows/kfdrc_process_pe_set.cwl
@@ -13,6 +13,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict'] 
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -46,6 +47,15 @@ steps:
       outputname_reads2:
         source: input_pe_mates
         valueFrom: TRIMMED.$(self.basename)
+      outputname_stats:
+        source: [output_basename, input_pe_rgs]
+        valueFrom: |
+          ${
+            var basename = self[0];
+            var rg_id = self[1].match(/ID:[A-Za-z0-9-_/]*?([A-Za-z0-9-_]*)\\t/);
+            var reads_name = inputs.input_reads1.basename.replace(/.f(ast)?[aq](\.gz)?$/,"");
+            return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"),  reads_name, "cutadapt_stats.txt"].join('.');
+          }
     out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
 
   zcat_split_reads:

--- a/subworkflows/kfdrc_process_se_readslist2.cwl
+++ b/subworkflows/kfdrc_process_se_readslist2.cwl
@@ -1,10 +1,11 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: Workflow
 id: kfdrc_process_se_readslist2
 requirements:
   - class: ScatterFeatureRequirement
   - class: MultipleInputFeatureRequirement
   - class: SubworkflowFeatureRequirement
+  - class: InlineJavascriptRequirement
 inputs:
   input_se_reads_list: File[]
   input_se_rgs_list: string[]
@@ -13,6 +14,10 @@ inputs:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
   min_alignment_score: int?
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
 outputs:
   unsorted_bams: 
     type:
@@ -21,6 +26,7 @@ outputs:
         type: array
         items: File
     outputSource: process_se_set/unsorted_bams 
+  cutadapt_stats: { type: 'File[]?', outputSource: process_se_set/cutadapt_stats }
 
 steps:
   process_se_set:
@@ -30,9 +36,13 @@ steps:
       input_se_reads: input_se_reads_list
       input_se_rgs: input_se_rgs_list
       min_alignment_score: min_alignment_score
+      cutadapt_r1_adapter: cutadapt_r1_adapter
+      cutadapt_min_len: cutadapt_min_len
+      cutadapt_quality_base: cutadapt_quality_base
+      cutadapt_quality_cutoff: cutadapt_quality_cutoff
     scatter: [input_se_reads, input_se_rgs]
     scatterMethod: dotproduct
-    out: [unsorted_bams]
+    out: [unsorted_bams, cutadapt_stats]
 
 $namespaces:
   sbg: https://sevenbridges.com

--- a/subworkflows/kfdrc_process_se_readslist2.cwl
+++ b/subworkflows/kfdrc_process_se_readslist2.cwl
@@ -13,6 +13,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '^.dict', '.fai']
+  output_basename: { type: 'string?' }
   min_alignment_score: int?
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -36,6 +37,7 @@ steps:
       input_se_reads: input_se_reads_list
       input_se_rgs: input_se_rgs_list
       min_alignment_score: min_alignment_score
+      output_basename: output_basename
       cutadapt_r1_adapter: cutadapt_r1_adapter
       cutadapt_min_len: cutadapt_min_len
       cutadapt_quality_base: cutadapt_quality_base

--- a/subworkflows/kfdrc_process_se_set.cwl
+++ b/subworkflows/kfdrc_process_se_set.cwl
@@ -1,30 +1,55 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: Workflow
 id: kfdrc_process_se_set
 requirements:
   - class: ScatterFeatureRequirement
   - class: MultipleInputFeatureRequirement
   - class: SubworkflowFeatureRequirement
+  - class: InlineJavascriptRequirement
 inputs:
   input_se_reads: File
   input_se_rgs: string
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: int?
 outputs:
   unsorted_bams: 
     type: File[]
     outputSource: bwa_mem_split_se_reads/output
+  cutadapt_stats: { type: 'File?', outputSource: cutadapt/cutadapt_stats }
 
 steps:
+  cutadapt:
+    run: ../tools/cutadapt.cwl
+    when: |
+      $(inputs.r1_threeprime_adapter != null)
+    in:
+      input_reads1: input_se_reads
+      interleaved:
+        valueFrom: $(1 == 0)
+      r1_threeprime_adapter: cutadapt_r1_adapter
+      minimum_length: cutadapt_min_len
+      quality_base: cutadapt_quality_base
+      quality_cutoff: cutadapt_quality_cutoff
+      outputname_reads1:
+        source: input_se_reads
+        valueFrom: TRIMMED.$(self.basename)
+    out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
+
   zcat_split_reads:
     hints:
       - class: 'sbg:AWSInstanceType'
         value: c5.9xlarge
     run: ../tools/fastq_chomp.cwl
     in:
-      input_fastq: input_se_reads
+      input_fastq:
+        source: [cutadapt/trimmed_output, input_se_reads]
+        pickValue: first_non_null
     out: [output]
  
   bwa_mem_split_se_reads:

--- a/subworkflows/kfdrc_process_se_set.cwl
+++ b/subworkflows/kfdrc_process_se_set.cwl
@@ -12,6 +12,7 @@ inputs:
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
   cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
@@ -39,6 +40,15 @@ steps:
       outputname_reads1:
         source: input_se_reads
         valueFrom: TRIMMED.$(self.basename)
+      outputname_stats:
+        source: [output_basename, input_se_rgs]
+        valueFrom: |
+          ${
+            var basename = self[0];
+            var rg_id = self[1].match(/ID:[A-Za-z0-9-_/]*?([A-Za-z0-9-_]*)\\t/);
+            var reads_name = inputs.input_reads1.basename.replace(/.f(ast)?[aq](\.gz)?$/,"");
+            return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"),  reads_name, "cutadapt_stats.txt"].join('.');
+          }
     out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
 
   zcat_split_reads:

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -11,6 +11,7 @@ inputs:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  output_basename: { type: 'string?' }
   cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
   cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
@@ -58,6 +59,15 @@ steps:
       quality_cutoff: cutadapt_quality_cutoff
       outputname_reads1:
         valueFrom: TRIMMED.$(inputs.input_reads1.basename)
+      outputname_stats:
+        source: [output_basename, expression_updatergsample/rg_str]
+        valueFrom: |
+          ${
+            var basename = self[0];
+            var rg_id = self[1].match(/ID:[A-Za-z0-9-_/]*?([A-Za-z0-9-_]*)\\t/);
+            var reads_name = inputs.input_reads1.basename.replace(/.f(ast)?[aq](\.gz)?$/,"");
+            return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"),  reads_name, "cutadapt_stats.txt"].join('.');
+          }
     out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
 
   expression_pick_filelist:

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -1,14 +1,21 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: Workflow
 id: kfdrc_rgbam_to_realnbam
 requirements:
   - class: ScatterFeatureRequirement
+  - class: InlineJavascriptRequirement
+  - class: MultipleInputFeatureRequirement
 inputs:
   input_rgbam: File
   indexed_reference_fasta:
     type: File
     secondaryFiles: ['.64.amb', '.64.ann', '.64.bwt', '.64.pac', '.64.sa', '.64.alt', '^.dict']
   sample_name: string
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: int?
   cram_reference: { type: 'File?', doc: "If aligning from cram, need to provided reference used to generate that cram" }
   bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
@@ -17,6 +24,7 @@ outputs:
   unsorted_bams:
     type: File[]
     outputSource: bwa_mem_naive_bam/output
+  cutadapt_stats: { type: 'File[]?', outputSource: cutadapt/cutadapt_stats }
 
 steps:
   bamtofastq_chomp:
@@ -34,11 +42,49 @@ steps:
       sample: sample_name
     out: [rg_str]
 
+  cutadapt:
+    run: ../tools/cutadapt.cwl
+    when: |
+      $(inputs.r1_threeprime_adapter != null && inputs.r2_threeprime_adapter != null)
+    scatter: [input_reads1]
+    in:
+      input_reads1: bamtofastq_chomp/output
+      interleaved:
+        valueFrom: $(1 == 1)
+      r1_threeprime_adapter: cutadapt_r1_adapter
+      r2_threeprime_adapter: cutadapt_r2_adapter
+      minimum_length: cutadapt_min_len
+      quality_base: cutadapt_quality_base
+      quality_cutoff: cutadapt_quality_cutoff
+      outputname_reads1:
+        valueFrom: TRIMMED.$(inputs.input_reads1.basename)
+    out: [ trimmed_output, trimmed_paired_output, cutadapt_stats ]
+
+  expression_pick_filelist:
+    hints:
+    - class: "sbg:AWSInstanceType"
+      value: c5.9xlarge
+    run:
+      class: ExpressionTool
+      requirements:
+        InlineJavascriptRequirement: {}
+      inputs:
+        in_filelist: { type: 'File[]' }
+      outputs:
+        out_filelist: { type: 'File[]' }
+      expression: |
+        $({"out_filelist": inputs.in_filelist})
+    in:
+      in_filelist:
+        source: [cutadapt/trimmed_output, bamtofastq_chomp/output]
+        pickValue: first_non_null
+    out: [out_filelist]
+
   bwa_mem_naive_bam:
     run: ../tools/bwa_mem_naive.cwl
     in:
       ref: indexed_reference_fasta
-      reads: bamtofastq_chomp/output
+      reads: expression_pick_filelist/out_filelist
       interleaved:
         default: true
       rg: expression_updatergsample/rg_str

--- a/tools/cutadapt.cwl
+++ b/tools/cutadapt.cwl
@@ -17,7 +17,7 @@ requirements:
     coresMin: $(inputs.cpu)
     ramMin: $(inputs.ram * 1000)
 baseCommand: [cutadapt]
-stdout: $(inputs.outputname_reads1.replace(/.f(ast)?[aq](\.gz)?$/, ".cutadapt_stats.txt"))
+stdout: $(inputs.outputname_stats)
 inputs:
   input_reads1: { type: 'File', inputBinding: { position: 8 }, doc: "FASTQ file containing reads1 or interleaved reads." }
   input_reads2: { type: 'File?', inputBinding: { position: 9 },  doc: "FASTQ file containing reads2." }
@@ -29,6 +29,7 @@ inputs:
   quality_cutoff: {type: 'string?', default: "0", inputBinding: { position: 2, prefix: "--quality-cutoff" }, doc: "Quality trim cutoff. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   outputname_reads1: { type: 'string?', default: "reads1.trimmed.fastq", inputBinding: { position: 2, prefix: "--output" }, doc: "Write trimmed reads to FILE. Can be FASTQ or FASTA format" }
   outputname_reads2: { type: 'string?', inputBinding: { position: 2, prefix: "--paired-output" }, doc: "Write R2 to FILE." }
+  outputname_stats: { type: 'string?', default: "cutadapt_stats.txt", doc: "Name for stats output file." }
   additional_args: {type: 'string?', inputBinding: { position: 2, shellQuote: false }, doc: "Any additional args to be set"}
   cpu: { type: 'int?', default: 8, inputBinding: { position: 2, prefix: "--cores" }, doc: "CPUs to allocate to this task" }
   ram: { type: 'int?', default: 16, doc: "GB of RAM to allocate to this task" }

--- a/tools/cutadapt.cwl
+++ b/tools/cutadapt.cwl
@@ -1,0 +1,45 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: cutadapt
+doc: |
+  Using an interleaved FASTQ file input, use cutadapt to:
+  - Trim bases with quality less than quality_cutoff from the 3' and 5' ends of the reads
+  - Trim r1_threeprime_adapter from the 3' of read1
+  - Trim r2_threeprime_adapter from the 3' of read2
+  - Discard any read pairs that have a read shorter than 20 bases
+  - Return the resulting reads as an interleaved FASTQ
+requirements:
+  - class: ShellCommandRequirement
+  - class: DockerRequirement
+    dockerPull: 'quay.io/biocontainers/cutadapt:4.6--py310h4b81fae_1'
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    coresMin: $(inputs.cpu)
+    ramMin: $(inputs.ram * 1000)
+baseCommand: [cutadapt]
+stdout: $(inputs.outputname_reads1.replace(/.f(ast)?[aq](\.gz)?$/, ".cutadapt_stats.txt"))
+inputs:
+  input_reads1: { type: 'File', inputBinding: { position: 8 }, doc: "FASTQ file containing reads1 or interleaved reads." }
+  input_reads2: { type: 'File?', inputBinding: { position: 9 },  doc: "FASTQ file containing reads2." }
+  interleaved: { type: 'boolean?', inputBinding: { position: 2, prefix: "--interleaved" }, doc: "Read and/or write interleaved paired-end reads." }
+  r1_threeprime_adapter: { type: 'string', inputBinding: { position: 2, prefix: "-a" }, doc: "regular 3' adapter sequence to remove from read1" }
+  r2_threeprime_adapter: { type: 'string?', inputBinding: { position: 2, prefix: "-A" }, doc: "regular 3' adapter sequence to remove from read2" }
+  minimum_length: { type: 'int?', default: 20, inputBinding: { position: 2, prefix: "--minimum-length" }, doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output" }
+  quality_base: { type: 'int?', default: 33, inputBinding: { position: 2, prefix: "--quality-base" }, doc: "Phred scale used" }
+  quality_cutoff: {type: 'string?', default: "0", inputBinding: { position: 2, prefix: "--quality-cutoff" }, doc: "Quality trim cutoff. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
+  outputname_reads1: { type: 'string?', default: "reads1.trimmed.fastq", inputBinding: { position: 2, prefix: "--output" }, doc: "Write trimmed reads to FILE. Can be FASTQ or FASTA format" }
+  outputname_reads2: { type: 'string?', inputBinding: { position: 2, prefix: "--paired-output" }, doc: "Write R2 to FILE." }
+  additional_args: {type: 'string?', inputBinding: { position: 2, shellQuote: false }, doc: "Any additional args to be set"}
+  cpu: { type: 'int?', default: 8, inputBinding: { position: 2, prefix: "--cores" }, doc: "CPUs to allocate to this task" }
+  ram: { type: 'int?', default: 16, doc: "GB of RAM to allocate to this task" }
+outputs:
+  trimmed_output:
+    type: File
+    outputBinding:
+      glob: $(inputs.outputname_reads1) 
+  trimmed_paired_output:
+    type: File
+    outputBinding:
+      glob: $(inputs.outputname_reads2)
+  cutadapt_stats:
+    type: stdout 

--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -102,6 +102,7 @@ doc: |+
     cram: {type: File, outputSource: samtools_bam_to_cram/output, doc: "(Re)Aligned Reads File"}
     gvcf: {type: 'File[]?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated from the realigned alignment file."}
     verifybamid_output: {type: 'File[]?', outputSource: generate_gvcf/verifybamid_output, doc: "Ouput from VerifyBamID that is used to calculate contamination."}
+    cutadapt_stats: { type: 'File[]?', outputSource: collect_cutadapt_stats/out_filelist, doc: "Stats from Cutadapt runs, if run. One or more per read group." }
     bqsr_report: {type: File, outputSource: gatk_gatherbqsrreports/output, doc: "Recalibration report from BQSR."}
     gvcf_calling_metrics: {type: ['null', {type: array, items: {type: array, items: File}}], outputSource: generate_gvcf/gvcf_calling_metrics, doc: "General metrics for gVCF calling quality."}
     hs_metrics: {type: 'File[]?', outputSource: picard_collecthsmetrics/output, doc: "Picard CollectHsMetrics metrics for the analysis of target-capture sequencing experiments."}
@@ -507,7 +508,8 @@ outputs:
       Reads File"}
   gvcf: {type: 'File[]?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated
       from the realigned alignment file."}
-  cutadapt_stats: { type: 'File[]?', outputSource: collect_cutadapt_stats/out_filelist }
+  cutadapt_stats: {type: 'File[]?', outputSource: collect_cutadapt_stats/out_filelist,
+    doc: "Stats from Cutadapt runs, if run. One or more per read group."}
   verifybamid_output: {type: 'File[]?', outputSource: generate_gvcf/verifybamid_output,
     doc: "Ouput from VerifyBamID that is used to calculate contamination."}
   bqsr_report: {type: File, outputSource: gatk_gatherbqsrreports/output, doc: "Recalibration
@@ -670,7 +672,7 @@ steps:
               return ret;
           }
       inputs:
-        in_filelist: { type: 'Any?' }
+        in_filelist: {type: 'Any?'}
       outputs:
         out_filelist:
           type: File[]
@@ -681,7 +683,6 @@ steps:
       in_filelist:
         source: [process_bams/cutadapt_stats, process_pe_reads/cutadapt_stats, process_se_reads/cutadapt_stats]
     out: [out_filelist]
-
   sambamba_merge:
     hints:
     - class: "sbg:AWSInstanceType"

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -201,6 +201,7 @@ outputs:
       from the realigned alignment file."}
   verifybamid_output: {type: 'File?', outputSource: generate_gvcf/verifybamid_output,
     doc: "Ouput from VerifyBamID that is used to calculate contamination."}
+  cutadapt_stats: {type: 'File[]?', outputSource: sentieon_bwa_mem_payloads/cutadapt_stats, doc: "Stats from Cutadapt activity on inputs."}
   bqsr_report: {type: File, outputSource: sentieon_bqsr/recal_table, doc: "Recalibration
       report from BQSR."}
   gvcf_calling_metrics: {type: 'File[]?', outputSource: generate_gvcf/gvcf_calling_metrics,
@@ -323,6 +324,7 @@ steps:
     in:
       sentieon_license: sentieon_license
       indexed_reference_fasta: untar_reference/indexed_fasta
+      output_basename: output_basename
       cutadapt_r1_adapter: cutadapt_r1_adapter
       cutadapt_r2_adapter: cutadapt_r2_adapter
       cutadapt_min_len: cutadapt_min_len

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -174,6 +174,11 @@ inputs:
   run_gvcf_processing: {type: boolean, doc: "gVCF will be generated. Requires: dbsnp_vcf,\
       \ contamination_sites_bed, contamination_sites_mu, contamination_sites_ud, and\
       \ wgs_evaluation_interval_list."}
+  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
+  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
+  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
+  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
+  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   min_alignment_score: {type: 'int?', default: 30, doc: "For BWA MEM, Don't output\
       \ alignment with score lower than INT. This option only affects output."}
   samtools_split_max_memory: {type: 'int?', default: 36, doc: "GB of RAM to allocate\
@@ -309,13 +314,18 @@ steps:
     in:
       sentieon_license: sentieon_license
       indexed_reference_fasta: untar_reference/indexed_fasta
+      cutadapt_r1_adapter: cutadapt_r1_adapter
+      cutadapt_r2_adapter: cutadapt_r2_adapter
+      cutadapt_min_len: cutadapt_min_len
+      cutadapt_quality_base: cutadapt_quality_base
+      cutadapt_quality_cutoff: cutadapt_quality_cutoff
       min_alignment_score: min_alignment_score
       bwa_payload:
         source: [prepare_bam_bwa_payloads/bwa_payload, prepare_pe_fq_bwa_payloads/bwa_payload,
           prepare_se_fq_bwa_payloads/bwa_payload]
         linkMerge: merge_flattened
         pickValue: all_non_null
-    out: [realgn_bam]
+    out: [realgn_bam, cutadapt_stats]
   sentieon_readwriter_merge_bams:
     run: ../tools/sentieon_ReadWriter.cwl
     in:

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -110,138 +110,147 @@ requirements:
 - class: SubworkflowFeatureRequirement
 - class: InlineJavascriptRequirement
 inputs:
-  sentieon_license: {type: 'string?', default: "10.5.64.221:8990", doc: "License server\
-      \ host and port"}
+  sentieon_license: {type: 'string?', default: "10.5.64.221:8990", doc: "License server
+      host and port"}
   input_bam_list: {type: 'File[]?', doc: "List of input BAM files"}
   input_pe_reads_list: {type: 'File[]?', doc: "List of input R1 paired end fastq reads"}
   input_pe_mates_list: {type: 'File[]?', doc: "List of input R2 paired end fastq reads"}
   input_pe_rgs_list: {type: 'string[]?', doc: "List of RG strings to use in PE processing"}
   input_se_reads_list: {type: 'File[]?', doc: "List of input single end fastq reads"}
   input_se_rgs_list: {type: 'string[]?', doc: "List of RG strings to use in SE processing"}
-  reference_tar: {type: File, doc: "Tar file containing a reference fasta and, optionally,\
-      \ its complete set of associated indexes (samtools, bwa, and picard)", "sbg:suggestedValue": {
+  reference_tar: {type: File, doc: "Tar file containing a reference fasta and, optionally,
+      its complete set of associated indexes (samtools, bwa, and picard)", "sbg:suggestedValue": {
       class: File, path: 5f4ffff4e4b0370371c05153, name: Homo_sapiens_assembly38.tgz}}
-  cram_reference: {type: 'File?', doc: "If aligning from cram, need to provided reference\
-      \ used to generate that cram"}
+  cram_reference: {type: 'File?', doc: "If aligning from cram, need to provided reference
+      used to generate that cram"}
   biospecimen_name: {type: string, doc: "String name of biospcimen"}
   output_basename: {type: string, doc: "String to use as the base for output filenames"}
   dbsnp_vcf: {type: 'File?', doc: "dbSNP vcf file", "sbg:suggestedValue": {class: File,
       path: 6063901f357c3a53540ca84b, name: Homo_sapiens_assembly38.dbsnp138.vcf}}
   dbsnp_idx: {type: 'File?', doc: "dbSNP vcf index file", "sbg:suggestedValue": {
       class: File, path: 6063901e357c3a53540ca834, name: Homo_sapiens_assembly38.dbsnp138.vcf.idx}}
-  knownsites: {type: 'File[]', doc: "List of files containing known polymorphic sites\
-      \ used to exclude regions around known polymorphisms from analysis", "sbg:suggestedValue": [
+  knownsites: {type: 'File[]', doc: "List of files containing known polymorphic sites
+      used to exclude regions around known polymorphisms from analysis", "sbg:suggestedValue": [
       {class: File, path: 6063901e357c3a53540ca835, name: 1000G_omni2.5.hg38.vcf.gz},
       {class: File, path: 6063901c357c3a53540ca80f, name: 1000G_phase1.snps.high_confidence.hg38.vcf.gz},
       {class: File, path: 60639017357c3a53540ca7d0, name: Homo_sapiens_assembly38.known_indels.vcf.gz},
       {class: File, path: 6063901a357c3a53540ca7f3, name: Mills_and_1000G_gold_standard.indels.hg38.vcf.gz}]}
-  knownsites_indexes: {type: 'File[]?', doc: "Corresponding indexes for the knownsites.\
-      \ File position in list must match with its corresponding VCF's position in\
-      \ the knownsites file list. For example, if the first file in the knownsites\
-      \ list is 1000G_omni2.5.hg38.vcf.gz then the first item in this list must be\
-      \ 1000G_omni2.5.hg38.vcf.gz.tbi. Optional, but will save time/cost on indexing.",
-    "sbg:suggestedValue": [{class: File, path: 60639016357c3a53540ca7b1, name: 1000G_omni2.5.hg38.vcf.gz.tbi},
-      {class: File, path: 6063901e357c3a53540ca845, name: 1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi},
+  knownsites_indexes: {type: 'File[]?', doc: "Corresponding indexes for the knownsites.
+      File position in list must match with its corresponding VCF's position in the
+      knownsites file list. For example, if the first file in the knownsites list
+      is 1000G_omni2.5.hg38.vcf.gz then the first item in this list must be 1000G_omni2.5.hg38.vcf.gz.tbi.
+      Optional, but will save time/cost on indexing.", "sbg:suggestedValue": [{class: File,
+        path: 60639016357c3a53540ca7b1, name: 1000G_omni2.5.hg38.vcf.gz.tbi}, {class: File,
+        path: 6063901e357c3a53540ca845, name: 1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi},
       {class: File, path: 6063901c357c3a53540ca80d, name: Homo_sapiens_assembly38.known_indels.vcf.gz.tbi},
       {class: File, path: 6063901c357c3a53540ca806, name: Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi}]}
-  contamination_sites_bed: {type: 'File?', doc: ".bed file for markers used in this\
-      \ analysis,format(chr\tpos-1\tpos\trefAllele\taltAllele)", "sbg:suggestedValue": {
+  contamination_sites_bed: {type: 'File?', doc: ".bed file for markers used in this
+      analysis,format(chr\tpos-1\tpos\trefAllele\taltAllele)", "sbg:suggestedValue": {
       class: File, path: 6063901e357c3a53540ca833, name: Homo_sapiens_assembly38.contam.bed}}
   contamination_sites_mu: {type: 'File?', doc: ".mu matrix file of genotype matrix",
     "sbg:suggestedValue": {class: File, path: 60639017357c3a53540ca7cd, name: Homo_sapiens_assembly38.contam.mu}}
-  contamination_sites_ud: {type: 'File?', doc: ".UD matrix file from SVD result of\
-      \ genotype matrix", "sbg:suggestedValue": {class: File, path: 6063901f357c3a53540ca84f,
+  contamination_sites_ud: {type: 'File?', doc: ".UD matrix file from SVD result of
+      genotype matrix", "sbg:suggestedValue": {class: File, path: 6063901f357c3a53540ca84f,
       name: Homo_sapiens_assembly38.contam.UD}}
-  wgs_coverage_interval_list: {type: 'File?', doc: "An interval list file that contains\
-      \ the positions to restrict the wgs metrics assessment", "sbg:suggestedValue": {
+  wgs_coverage_interval_list: {type: 'File?', doc: "An interval list file that contains
+      the positions to restrict the wgs metrics assessment", "sbg:suggestedValue": {
       class: File, path: 6063901c357c3a53540ca813, name: wgs_coverage_regions.hg38.interval_list}}
-  wgs_evaluation_interval_list: {type: 'File?', doc: "Target intervals to restrict\
-      \ gvcf metric analysis (for VariantCallingMetrics)", "sbg:suggestedValue": {
-      class: File, path: 60639017357c3a53540ca7d3, name: wgs_evaluation_regions.hg38.interval_list}}
-  wxs_bait_interval_list: {type: 'File?', doc: "An interval list file that contains\
-      \ the locations of the WXS baits used (for HsMetrics)"}
-  wxs_target_interval_list: {type: 'File?', doc: "An interval list file that contains\
-      \ the locations of the WXS targets (for HsMetrics)"}
-  run_hs_metrics: {type: boolean, doc: "HsMetrics will be collected. Only recommended\
-      \ for WXS inputs. Requires: wxs_bait_interval_list, wxs_target_interval_list"}
-  run_wgs_metrics: {type: boolean, doc: "WgsMetrics will be collected. Only recommended\
-      \ for WGS inputs. Requires: wgs_coverage_interval_list"}
-  run_agg_metrics: {type: boolean, doc: "AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics,\
-      \ QualityScoreDistribution, and SequencingArtifactMetrics will be collected.\
-      \ Recommended for both WXS and WGS inputs."}
-  run_sex_metrics: {type: boolean, doc: "idxstats will be collected and X/Y ratios\
-      \ calculated."}
-  run_gvcf_processing: {type: boolean, doc: "gVCF will be generated. Requires: dbsnp_vcf,\
-      \ contamination_sites_bed, contamination_sites_mu, contamination_sites_ud, and\
-      \ wgs_evaluation_interval_list."}
-  cutadapt_r1_adapter: { type: 'string?', doc: "If read1 reads have an adapter, provide regular 3' adapter sequence here to remove it from read1" }
-  cutadapt_r2_adapter: { type: 'string?', doc: "If read2 reads have an adapter, provide regular 3' adapter sequence here to remove it from read2" }
-  cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
-  cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
-  cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
-  min_alignment_score: {type: 'int?', default: 30, doc: "For BWA MEM, Don't output\
-      \ alignment with score lower than INT. This option only affects output."}
-  samtools_split_max_memory: {type: 'int?', default: 36, doc: "GB of RAM to allocate\
-      \ to samtools split."}
-  samtools_split_cores: {type: 'int?', default: 36, doc: "Minimum reserved number\
-      \ of CPU cores for samtools split."}
+  wgs_evaluation_interval_list: {type: 'File?', doc: "Target intervals to restrict
+      gvcf metric analysis (for VariantCallingMetrics)", "sbg:suggestedValue": {class: File,
+      path: 60639017357c3a53540ca7d3, name: wgs_evaluation_regions.hg38.interval_list}}
+  wxs_bait_interval_list: {type: 'File?', doc: "An interval list file that contains
+      the locations of the WXS baits used (for HsMetrics)"}
+  wxs_target_interval_list: {type: 'File?', doc: "An interval list file that contains
+      the locations of the WXS targets (for HsMetrics)"}
+  run_hs_metrics: {type: boolean, doc: "HsMetrics will be collected. Only recommended
+      for WXS inputs. Requires: wxs_bait_interval_list, wxs_target_interval_list"}
+  run_wgs_metrics: {type: boolean, doc: "WgsMetrics will be collected. Only recommended
+      for WGS inputs. Requires: wgs_coverage_interval_list"}
+  run_agg_metrics: {type: boolean, doc: "AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics,
+      QualityScoreDistribution, and SequencingArtifactMetrics will be collected. Recommended
+      for both WXS and WGS inputs."}
+  run_sex_metrics: {type: boolean, doc: "idxstats will be collected and X/Y ratios
+      calculated."}
+  run_gvcf_processing: {type: boolean, doc: "gVCF will be generated. Requires: dbsnp_vcf,
+      contamination_sites_bed, contamination_sites_mu, contamination_sites_ud, and
+      wgs_evaluation_interval_list."}
+  cutadapt_r1_adapter: {type: 'string?', doc: "If read1 reads have an adapter, provide
+      regular 3' adapter sequence here to remove it from read1"}
+  cutadapt_r2_adapter: {type: 'string?', doc: "If read2 reads have an adapter, provide
+      regular 3' adapter sequence here to remove it from read2"}
+  cutadapt_min_len: {type: 'int?', doc: "If adapter trimming, discard reads/read-pairs
+      where the read length is less than this value. Set to 0 to turn off"}
+  cutadapt_quality_base: {type: 'int?', doc: "If adapter trimming, use this value
+      as the base quality score. Defaults to 33 but very old reads might need this
+      value set to 64"}
+  cutadapt_quality_cutoff: {type: 'string?', doc: "If adapter trimming, remove bases
+      from the 3'/5' that fail to meet this cutoff value. If you specify a single
+      cutoff value, the 3' end of each read is trimmed. If you specify two cutoff
+      values separated by a comma, the first value will be trimmed from the 5' and
+      the second value will be trimmed from the 3'"}
+  min_alignment_score: {type: 'int?', default: 30, doc: "For BWA MEM, Don't output
+      alignment with score lower than INT. This option only affects output."}
+  samtools_split_max_memory: {type: 'int?', default: 36, doc: "GB of RAM to allocate
+      to samtools split."}
+  samtools_split_cores: {type: 'int?', default: 36, doc: "Minimum reserved number
+      of CPU cores for samtools split."}
 outputs:
-  cram: {type: File, outputSource: sentieon_readwriter_bam_to_cram/output_reads, doc: "(Re)Aligned\
-      \ Reads File"}
-  gvcf: {type: 'File?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated\
-      \ from the realigned alignment file."}
+  cram: {type: File, outputSource: sentieon_readwriter_bam_to_cram/output_reads, doc: "(Re)Aligned
+      Reads File"}
+  gvcf: {type: 'File?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated
+      from the realigned alignment file."}
   verifybamid_output: {type: 'File?', outputSource: generate_gvcf/verifybamid_output,
     doc: "Ouput from VerifyBamID that is used to calculate contamination."}
-  bqsr_report: {type: File, outputSource: sentieon_bqsr/recal_table, doc: "Recalibration\
-      \ report from BQSR."}
+  bqsr_report: {type: File, outputSource: sentieon_bqsr/recal_table, doc: "Recalibration
+      report from BQSR."}
   gvcf_calling_metrics: {type: 'File[]?', outputSource: generate_gvcf/gvcf_calling_metrics,
     doc: "General metrics for gVCF calling quality."}
-  hs_metrics: {type: 'File?', outputSource: sentieon_hsmetrics/hs_output, doc: "Sentieon's\
-      \ Picard-like CollectHsMetrics metrics for the analysis of target-capture sequencing\
-      \ experiments."}
-  wgs_metrics: {type: 'File?', outputSource: sentieon_wgsmetrics/wgs_output, doc: "Sentieon's\
-      \ Picard-like CollectWgsMetrics metrics for evaluating the performance of whole\
-      \ genome sequencing experiments."}
+  hs_metrics: {type: 'File?', outputSource: sentieon_hsmetrics/hs_output, doc: "Sentieon's
+      Picard-like CollectHsMetrics metrics for the analysis of target-capture sequencing
+      experiments."}
+  wgs_metrics: {type: 'File?', outputSource: sentieon_wgsmetrics/wgs_output, doc: "Sentieon's
+      Picard-like CollectWgsMetrics metrics for evaluating the performance of whole
+      genome sequencing experiments."}
   alignment_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/as_output,
-    doc: "Sentieon's Picard-like CollectAlignmentSummaryMetrics high level metrics\
-      \ about the alignment of reads within a SAM file."}
+    doc: "Sentieon's Picard-like CollectAlignmentSummaryMetrics high level metrics
+      about the alignment of reads within a SAM file."}
   gc_bias_detail: {type: 'File?', outputSource: sentieon_aggmetrics/gc_bias_detail,
-    doc: "Sentieon's Picard-like CollectGcBiasMetrics detailed metrics about reads\
-      \ that fall within windows of a certain GC bin on the reference genome."}
+    doc: "Sentieon's Picard-like CollectGcBiasMetrics detailed metrics about reads
+      that fall within windows of a certain GC bin on the reference genome."}
   gc_bias_summary: {type: 'File?', outputSource: sentieon_aggmetrics/gc_bias_summary,
-    doc: "Sentieon's Picard-like CollectGcBiasMetrics high level metrics that capture\
-      \ how biased the coverage in a certain lane is."}
+    doc: "Sentieon's Picard-like CollectGcBiasMetrics high level metrics that capture
+      how biased the coverage in a certain lane is."}
   gc_bias_chart: {type: 'File?', outputSource: sentieon_aggmetrics/gc_bias_chart,
     doc: "Sentieon's Picard-like CollectGcBiasMetrics plot of GC bias."}
-  insert_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/is_metrics, doc: "Sentieon's\
-      \ Picard-like CollectInsertSizeMetrics metrics about the insert size distribution\
-      \ of a paired-end library."}
-  insert_plot: {type: 'File?', outputSource: sentieon_aggmetrics/is_plot, doc: "Sentieon's\
-      \ Picard-like CollectInsertSizeMetrics insert size distribution plotted."}
+  insert_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/is_metrics, doc: "Sentieon's
+      Picard-like CollectInsertSizeMetrics metrics about the insert size distribution
+      of a paired-end library."}
+  insert_plot: {type: 'File?', outputSource: sentieon_aggmetrics/is_plot, doc: "Sentieon's
+      Picard-like CollectInsertSizeMetrics insert size distribution plotted."}
   artifact_bait_bias_detail_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/sama_bait_bias_detail_metrics,
-    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics bait bias artifacts\
-      \ broken down by context."}
+    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics bait bias artifacts
+      broken down by context."}
   artifact_bait_bias_summary_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/sama_bait_bias_summary_metrics,
-    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary analysis\
-      \ of a single bait bias artifact."}
+    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary analysis
+      of a single bait bias artifact."}
   artifact_error_summary_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/sama_error_summary_metrics,
-    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary metrics\
-      \ as a roll up of the context-specific error rates, to provide global error\
-      \ rates per type of base substitution."}
+    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary metrics
+      as a roll up of the context-specific error rates, to provide global error rates
+      per type of base substitution."}
   artifact_pre_adapter_detail_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/sama_pre_adapter_detail_metrics,
-    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics pre-adapter artifacts\
-      \ broken down by context."}
+    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics pre-adapter artifacts
+      broken down by context."}
   artifact_pre_adapter_summary_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/sama_pre_adapter_summary_metrics,
-    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary analysis\
-      \ of a single pre-adapter artifact."}
-  qual_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/qd_metrics, doc: "Quality\
-      \ metrics for the realigned CRAM."}
-  qual_chart: {type: 'File?', outputSource: sentieon_aggmetrics/qd_chart, doc: "Visualization\
-      \ of quality metrics."}
-  idxstats: {type: 'File?', outputSource: samtools_idxstats_xy_ratio/output, doc: "samtools\
-      \ idxstats of the realigned BAM file."}
-  xy_ratio: {type: 'File?', outputSource: samtools_idxstats_xy_ratio/ratio, doc: "Text\
-      \ file containing X and Y reads statistics generated from idxstats."}
+    doc: "Sentieon's Picard-like CollectSequencingArtifactMetrics summary analysis
+      of a single pre-adapter artifact."}
+  qual_metrics: {type: 'File?', outputSource: sentieon_aggmetrics/qd_metrics, doc: "Quality
+      metrics for the realigned CRAM."}
+  qual_chart: {type: 'File?', outputSource: sentieon_aggmetrics/qd_chart, doc: "Visualization
+      of quality metrics."}
+  idxstats: {type: 'File?', outputSource: samtools_idxstats_xy_ratio/output, doc: "samtools
+      idxstats of the realigned BAM file."}
+  xy_ratio: {type: 'File?', outputSource: samtools_idxstats_xy_ratio/ratio, doc: "Text
+      file containing X and Y reads statistics generated from idxstats."}
 steps:
   untar_reference:
     run: ../tools/untar_indexed_reference_2.cwl
@@ -444,5 +453,5 @@ hints:
 - GVCF
 - SENTIEON
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.9.1'
+- id: 'https://github.com/kids-first/kf-alignment-workflow/releases/tag/v2.10.0'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Adds Cutadapt to the BWA/GATK and Sentieon alignment workflows.

Breakdown:
- Add tool to perform cutadapt in various cases
- Add conditional cutadapt step to `subworkflows/bwa_payload_to_realn_bam.cwl`; complicated conditional to only run in the correct instances (r1 adapter for SE fastq and bam; r1+r2 adapters for PE fastq and bam)
- Adjust the bwa mem step of `subworkflows/bwa_payload_to_realn_bam.cwl` for new conditional source of files
- Add conditional cutadapt step to `subworkflows/kfdrc_process_pe_set.cwl`, `subworkflows/kfdrc_process_se_set.cwl`, and `subworkflows/kfdrc_rgbam_to_realnbam.cwl`; simpler conditionals for more constrained cases
- Add new expressionTool to `subworkflows/kfdrc_rgbam_to_realnbam.cwl` to circumvent a CAVATICA bug; CAVATICA was not performing `pickValue` before `scatter` in  `bwa_mem_naive_bam` step input so I moved the `pickValue` operation to a preceding step to force it
- Adjust `zcat_split_reads` steps of `subworkflows/kfdrc_process_pe_set.cwl`, `subworkflows/kfdrc_process_se_set.cwl`, and `subworkflows/kfdrc_rgbam_to_realnbam.cwl` for new conditional source of files
- Propagate input and output values through workflows: `subworkflows/kfdrc_process_bam.cwl`, `subworkflows/kfdrc_process_bamlist.cwl`, `subworkflows/kfdrc_process_pe_readslist2.cwl`, `subworkflows/kfdrc_process_se_readslist2.cwl`, `workflows/kfdrc_alignment_wf.cwl`, and `workflows/kfdrc_sentieon_alignment_wf.cwl`
- Documentation updated to include cutadapt inputs
- Updated public apps for BWA/GATK and Sentieon alignment workflows
- Bumped version
- Give unique names to the `cutadapt_stats` files in the format `<output_basename>.<rg_id>.<reads1_rootname>.cutadapt_stats.txt`
- Return all cutadapt stats generated by a workflow as a file list

Part of https://github.com/d3b-center/bixu-tracker/issues/2250

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Lots of test scenarios for this one due to the multi-input options of the workflows:
- [x] Sentieon trimming off: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/f3e39c13-1d6c-4c1b-ac08-87498b02cd5e
- [x] Sentieon MultiRG BAM: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/13d25a40-f890-4304-8d69-9fc2d14528ce/
- [x] Sentieon PE FASTQ: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/e411e47d-bd4e-4cf4-aaba-1fc1cdaf700f/
- [x] Sentieon SE FASTQ: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/0990b9ab-9fcc-4f2f-8037-72de71d54577/
- [x] BWA/GATK Trimming Off: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/fcacec4d-2d52-4ac3-a12b-6c1cff4fca86/#
- [x] BWA/GATK MultiRG BAM: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/d3a0873c-1a60-4bfe-a649-f96576debc7a/
- [x] BWA/GATK PE FASTQ: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/8f18fedd-ca70-41a5-afe6-bed90c46e143/
- [x] BWA/GATK SE FASTQ: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/8f4c4b6a-19fd-467d-95a6-68691f4b8074/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
