### PR TITLE
🐛 alignment workflow cwltool compatibility

### DIFF
--- a/scripts/create_sequence_groups.py
+++ b/scripts/create_sequence_groups.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import sys
+
+def main():
+    with open(sys.argv[-1], "r") as ref_dict_file:
+        sequence_tuple_list = []
+        longest_sequence = 0
+        for line in ref_dict_file:
+            if line.startswith("@SQ"):
+                line_split = line.split(chr(9))
+                sequence_tuple_list.append((line_split[1].split("SN:")[1], int(line_split[2].split("LN:")[1])))
+        longest_sequence = sorted(sequence_tuple_list, key=lambda x: x[1], reverse=True)[0][1]
+    hg38_protection_tag = ":1+"
+    tsv_string = sequence_tuple_list[0][0] + hg38_protection_tag
+    temp_size = sequence_tuple_list[0][1]
+    i = 0
+    for sequence_tuple in sequence_tuple_list[1:]:
+        if temp_size + sequence_tuple[1] <= longest_sequence:
+            temp_size += sequence_tuple[1]
+            tsv_string += chr(10) + sequence_tuple[0] + hg38_protection_tag
+        else:
+            i += 1
+            pad = "{:0>2d}".format(i)
+            tsv_file_name = "sequence_grouping_" + pad + ".intervals"
+            with open(tsv_file_name, "w") as tsv_file:
+                tsv_file.write(tsv_string)
+                tsv_file.close()
+            tsv_string = sequence_tuple[0] + hg38_protection_tag
+            temp_size = sequence_tuple[1]
+    i += 1
+    pad = "{:0>2d}".format(i)
+    tsv_file_name = "sequence_grouping_" + pad + ".intervals"
+    with open(tsv_file_name, "w") as tsv_file:
+        tsv_file.write(tsv_string)
+        tsv_file.close()
+
+    with open("unmapped.intervals", "w") as tsv_file:
+        tsv_file.write("unmapped")
+        tsv_file.close()
+
+if __name__ == "__main__":
+    main()

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -89,7 +89,7 @@ steps:
       in_filelist:
         source: [cutadapt/trimmed_output, bamtofastq_chomp/output]
         valueFrom: |
-          $(self[0].some(function(e) { return e != null }) ? self[0] : self[1])
+          $(self[0].every(function(e) { return e != null }) ? self[0] : self[1])
     out: [out_filelist]
 
   bwa_mem_naive_bam:

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -89,7 +89,7 @@ steps:
       in_filelist:
         source: [cutadapt/trimmed_output, bamtofastq_chomp/output]
         valueFrom: |
-          $(self[0].every(function(e) { return e != null }) ? self[0] : self[1])
+          $(self[0] != null && self[0].every(function(e) { return e != null }) ? self[0] : self[1])
     out: [out_filelist]
 
   bwa_mem_naive_bam:

--- a/subworkflows/kfdrc_rgbam_to_realnbam.cwl
+++ b/subworkflows/kfdrc_rgbam_to_realnbam.cwl
@@ -4,6 +4,7 @@ id: kfdrc_rgbam_to_realnbam
 requirements:
   - class: ScatterFeatureRequirement
   - class: InlineJavascriptRequirement
+  - class: StepInputExpressionRequirement
   - class: MultipleInputFeatureRequirement
 inputs:
   input_rgbam: File
@@ -87,7 +88,8 @@ steps:
     in:
       in_filelist:
         source: [cutadapt/trimmed_output, bamtofastq_chomp/output]
-        pickValue: first_non_null
+        valueFrom: |
+          $(self[0].some(function(e) { return e != null }) ? self[0] : self[1])
     out: [out_filelist]
 
   bwa_mem_naive_bam:

--- a/tools/picard_collectgcbiasmetrics_conditional.cwl
+++ b/tools/picard_collectgcbiasmetrics_conditional.cwl
@@ -34,5 +34,5 @@ inputs:
   conditional_run: { type: int, doc: "Placeholder variable to allow conditional running" } 
 outputs:
   detail: { type: File, outputBinding: { glob: '*.gc_bias_metrics.txt' } }
-  summary: { type: File, outputBinding: { glob: '*.summary_metrics.txt' } }
+  summary: { type: File, outputBinding: { glob: '*.gc_bias_summary_metrics.txt' } }
   chart: { type: File, outputBinding: { glob: '*.gc_bias_metrics.pdf' } }

--- a/tools/picard_qualityscoredistribution_conditional.cwl
+++ b/tools/picard_qualityscoredistribution_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9R'
+    dockerPull: '684194535433.dkr.ecr.us-east-1.amazonaws.com/d3b-healthomics:picard'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, QualityScoreDistribution]
 arguments:
   - position: 1

--- a/tools/picard_qualityscoredistribution_conditional.cwl
+++ b/tools/picard_qualityscoredistribution_conditional.cwl
@@ -13,7 +13,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 12000
   - class: DockerRequirement
-    dockerPull: '684194535433.dkr.ecr.us-east-1.amazonaws.com/d3b-healthomics:picard'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9R'
 baseCommand: [ java, -Xms5000m, -jar, /picard.jar, QualityScoreDistribution]
 arguments:
   - position: 1

--- a/tools/python_createsequencegroups.cwl
+++ b/tools/python_createsequencegroups.cwl
@@ -7,52 +7,62 @@ doc: |-
 requirements:
   - class: DockerRequirement
     dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/python:2.7.13'
+  - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
-baseCommand: [python, -c]
+  - class: InitialWorkDirRequirement
+    listing:
+      - writable: false
+        entryname: "create_sequence_groups.py"
+        entry: |
+          #!/usr/bin/env python
+
+          import sys
+
+          def main():
+              with open(sys.argv[-1], "r") as ref_dict_file:
+                  sequence_tuple_list = []
+                  longest_sequence = 0
+                  for line in ref_dict_file:
+                      if line.startswith("@SQ"):
+                          line_split = line.split(chr(9))
+                          sequence_tuple_list.append((line_split[1].split("SN:")[1], int(line_split[2].split("LN:")[1])))
+                  longest_sequence = sorted(sequence_tuple_list, key=lambda x: x[1], reverse=True)[0][1]
+              hg38_protection_tag = ":1+"
+              tsv_string = sequence_tuple_list[0][0] + hg38_protection_tag
+              temp_size = sequence_tuple_list[0][1]
+              i = 0
+              for sequence_tuple in sequence_tuple_list[1:]:
+                  if temp_size + sequence_tuple[1] <= longest_sequence:
+                      temp_size += sequence_tuple[1]
+                      tsv_string += chr(10) + sequence_tuple[0] + hg38_protection_tag
+                  else:
+                      i += 1
+                      pad = "{:0>2d}".format(i)
+                      tsv_file_name = "sequence_grouping_" + pad + ".intervals"
+                      with open(tsv_file_name, "w") as tsv_file:
+                          tsv_file.write(tsv_string)
+                          tsv_file.close()
+                      tsv_string = sequence_tuple[0] + hg38_protection_tag
+                      temp_size = sequence_tuple[1]
+              i += 1
+              pad = "{:0>2d}".format(i)
+              tsv_file_name = "sequence_grouping_" + pad + ".intervals"
+              with open(tsv_file_name, "w") as tsv_file:
+                  tsv_file.write(tsv_string)
+                  tsv_file.close()
+
+              with open("unmapped.intervals", "w") as tsv_file:
+                  tsv_file.write("unmapped")
+                  tsv_file.close()
+
+          if __name__ == "__main__":
+              main()
+baseCommand: []
 arguments:
   - position: 0
-    shellQuote: true
-    valueFrom: >-
-      def main():
-          with open("$(inputs.ref_dict.path)", "r") as ref_dict_file:
-              sequence_tuple_list = []
-              longest_sequence = 0
-              for line in ref_dict_file:
-                  if line.startswith("@SQ"):
-                      line_split = line.split(chr(9))
-                      sequence_tuple_list.append((line_split[1].split("SN:")[1], int(line_split[2].split("LN:")[1])))
-              longest_sequence = sorted(sequence_tuple_list, key=lambda x: x[1], reverse=True)[0][1]
-          hg38_protection_tag = ":1+"
-          tsv_string = sequence_tuple_list[0][0] + hg38_protection_tag
-          temp_size = sequence_tuple_list[0][1]
-          i = 0
-          for sequence_tuple in sequence_tuple_list[1:]:
-              if temp_size + sequence_tuple[1] <= longest_sequence:
-                  temp_size += sequence_tuple[1]
-                  tsv_string += chr(10) + sequence_tuple[0] + hg38_protection_tag
-              else:
-                  i += 1
-                  pad = "{:0>2d}".format(i)
-                  tsv_file_name = "sequence_grouping_" + pad + ".intervals"
-                  with open(tsv_file_name, "w") as tsv_file:
-                      tsv_file.write(tsv_string)
-                      tsv_file.close()
-                  tsv_string = sequence_tuple[0] + hg38_protection_tag
-                  temp_size = sequence_tuple[1]
-          i += 1
-          pad = "{:0>2d}".format(i)
-          tsv_file_name = "sequence_grouping_" + pad + ".intervals"
-          with open(tsv_file_name, "w") as tsv_file:
-              tsv_file.write(tsv_string)
-              tsv_file.close()
-
-          with open("unmapped.intervals", "w") as tsv_file:
-              tsv_file.write("unmapped")
-              tsv_file.close()
-
-      if __name__ == "__main__":
-          main()
-
+    shellQuote: false
+    valueFrom: |
+      python create_sequence_groups.py $(inputs.ref_dict.path)
 inputs:
   ref_dict: { type: File, doc: "Reference fasta dict file" }
 outputs:

--- a/tools/python_createsequencegroups.cwl
+++ b/tools/python_createsequencegroups.cwl
@@ -13,50 +13,8 @@ requirements:
     listing:
       - writable: false
         entryname: "create_sequence_groups.py"
-        entry: |
-          #!/usr/bin/env python
-
-          import sys
-
-          def main():
-              with open(sys.argv[-1], "r") as ref_dict_file:
-                  sequence_tuple_list = []
-                  longest_sequence = 0
-                  for line in ref_dict_file:
-                      if line.startswith("@SQ"):
-                          line_split = line.split(chr(9))
-                          sequence_tuple_list.append((line_split[1].split("SN:")[1], int(line_split[2].split("LN:")[1])))
-                  longest_sequence = sorted(sequence_tuple_list, key=lambda x: x[1], reverse=True)[0][1]
-              hg38_protection_tag = ":1+"
-              tsv_string = sequence_tuple_list[0][0] + hg38_protection_tag
-              temp_size = sequence_tuple_list[0][1]
-              i = 0
-              for sequence_tuple in sequence_tuple_list[1:]:
-                  if temp_size + sequence_tuple[1] <= longest_sequence:
-                      temp_size += sequence_tuple[1]
-                      tsv_string += chr(10) + sequence_tuple[0] + hg38_protection_tag
-                  else:
-                      i += 1
-                      pad = "{:0>2d}".format(i)
-                      tsv_file_name = "sequence_grouping_" + pad + ".intervals"
-                      with open(tsv_file_name, "w") as tsv_file:
-                          tsv_file.write(tsv_string)
-                          tsv_file.close()
-                      tsv_string = sequence_tuple[0] + hg38_protection_tag
-                      temp_size = sequence_tuple[1]
-              i += 1
-              pad = "{:0>2d}".format(i)
-              tsv_file_name = "sequence_grouping_" + pad + ".intervals"
-              with open(tsv_file_name, "w") as tsv_file:
-                  tsv_file.write(tsv_string)
-                  tsv_file.close()
-
-              with open("unmapped.intervals", "w") as tsv_file:
-                  tsv_file.write("unmapped")
-                  tsv_file.close()
-
-          if __name__ == "__main__":
-              main()
+        entry:
+          $include: ../scripts/create_sequence_groups.py
 baseCommand: []
 arguments:
   - position: 0

--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -675,9 +675,15 @@ steps:
         in_filelist: {type: 'Any?'}
       outputs:
         out_filelist:
-          type: File[]
+          type: File[]?
           outputBinding:
-            outputEval: $(flatten(inputs.in_filelist))
+            outputEval: |
+              ${
+                var flatarray = flatten(inputs.in_filelist);
+                var filearray = flatarray.filter(function(e) { return e != null });
+                var outarr = filearray.length > 0 ? filearray : null;
+                return outarr;
+              }
     when: $(inputs.in_filelist.some(function(e) { return e != null }))
     in:
       in_filelist:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR is a series of changes I made to the alignment workflow so that it could be run in a cwltool runner environment.
- Add missing requirements for rgbam subworkflow and python tool
- In rgbam workflow, I needed to adjust the input selection for the array picking tool. Basically, for conditional steps that are scattered, Cavativa/Bunny will represent an skipped scatter step as `null`; cwltool on the other hand will represent it as `[null, null, null, ...]`. I wrote an expression that handles both in a faux-first_non_null fashion
- Fixed a broken glob in a picard metrics tool
- For the createsequencegroups tool, I moved the python script from the command line to a file. We could probably go further and move this into the scripts dir. Either way, the old way of doing things was causing problems on HealthOmics so I had to modify it to make it work
- For the idxstats tool, I moved the awk script into its own file. I did this because the cwltool environment was not properly handling the newline declarations. It appears cwltool handles escapes in positional valueFroms different from cavatica. Moving the script to a standalone file maintains the appropriate escapes for both runners
- In the alignment workflow, I adjusted the cutadapt aggregation tool to get rid of `null` returns. This was something that was actually happening in Cavatica as well, but Cavatica doesn't do the output type validation like cwltool. Returning `null` in a `File[]` will cause an error in the latter so I changed the expression to get rid of those.

Closes https://github.com/d3b-center/bixu-tracker/issues/2291

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Works on AWS healthomics
- [x] Cutadapt off: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/6754e7a5-7c53-4a61-8177-c37bd823033c/#
- [x] Cutadapt on: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/97bff424-17e6-4e41-896a-e3bb1a2ddb81/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR