### PR TITLE
🐛  enforce array length

### DIFF
--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -577,11 +577,34 @@ steps:
           untar_reference/ann, untar_reference/bwt, untar_reference/pac, untar_reference/sa]
         linkMerge: merge_flattened
     out: [output]
+  pad_knownsites_indexes:
+    run:
+      class: CommandLineTool
+      cwlVersion: v1.2
+      baseCommand: [echo, done]
+      inputs:
+        in_filelist:
+          type:
+            type: array
+            items: ['null', File]
+      outputs:
+        out_filelist:
+          type:
+            type: array
+            items: ['null', File]
+          outputBinding:
+            outputEval: $(inputs.in_filelist)
+    in:
+      in_filelist:
+        source: [knownsites, knownsites_indexes]
+        valueFrom: |
+          $(self[0].map(function(v,i) { return (self[1] != null ? self[1][i] : self[1]) }))
+    out: [out_filelist]
   index_knownsites:
     run: ../tools/tabix_index.cwl
     in:
       input_file: knownsites
-      input_index: knownsites_indexes
+      input_index: pad_knownsites_indexes/out_filelist
     scatter: [input_file, input_index]
     scatterMethod: dotproduct
     out: [output]

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -258,11 +258,34 @@ steps:
     in:
       reference_tar: reference_tar
     out: [indexed_fasta, dict]
+  pad_knownsites_indexes:
+    run:
+      class: CommandLineTool
+      cwlVersion: v1.2
+      baseCommand: [echo, done]
+      inputs:
+        in_filelist:
+          type:
+            type: array
+            items: ['null', File]
+      outputs:
+        out_filelist:
+          type:
+            type: array
+            items: ['null', File]
+          outputBinding:
+            outputEval: $(inputs.in_filelist)
+    in:
+      in_filelist:
+        source: [knownsites, knownsites_indexes]
+        valueFrom: |
+          $(self[0].map(function(v,i) { return (self[1] != null ? self[1][i] : self[1]) }))
+    out: [out_filelist]
   index_knownsites:
     run: ../tools/tabix_index.cwl
     in:
       input_file: knownsites
-      input_index: knownsites_indexes
+      input_index: pad_knownsites_indexes/out_filelist
     scatter: [input_file, input_index]
     scatterMethod: dotproduct
     out: [output]


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Fixes the optional scattering functionality of knownsite indexing

Closes https://github.com/d3b-center/bixu-tracker/issues/2293

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Sentieon
- [x] With all knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/a18cc932-f7c8-46a1-9712-61c586882356/
- [x] With some knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/8cb104d6-a8c3-48b2-9be8-ac0b9cbde34b/
- [x] Without knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/2a7f92e4-50be-4e5a-8a27-0ea7bd6a18ca/

BWA/GATK
- [x] With all knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/42ef08a2-f486-4112-adb9-560575eb3508
- [x] With some knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/511cb9de-dc9e-4b80-9a08-2ac764dc6760
- [x] Without knownsite indexes: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/2280f790-6581-4e52-bd01-23de494441c0

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
