### PR TITLE
🐎  open bam processing resource ins

### DIFF
--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -30,8 +30,8 @@ inputs:
   cutadapt_min_len: { type: 'int?', doc: "If adapter trimming, discard reads/read-pairs where the read length is less than this value. Set to 0 to turn off" }
   cutadapt_quality_base: { type: 'int?', doc: "If adapter trimming, use this value as the base quality score. Defaults to 33 but very old reads might need this value set to 64" }
   cutadapt_quality_cutoff: { type: 'string?', doc: "If adapter trimming, remove bases from the 3'/5' that fail to meet this cutoff value. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
-  cpu_per_job: { type: 'int?' }
-  mem_per_job: { type: 'int?' }
+  bwa_cpu: { type: 'int?', doc: "CPUs to allocate to Sentieon BWA MEM." }
+  bwa_ram: { type: 'int?', doc: "RAM in GB to allocate to Sentieon BWA MEM." }
 outputs:
   realgn_bam:
     type: File
@@ -98,8 +98,8 @@ steps:
       min_alignment_score: min_alignment_score
       chunk_size:
         valueFrom: $(100000000)
-      cpu_per_job: cpu_per_job
-      mem_per_job: mem_per_job
+      cpu_per_job: bwa_cpu
+      mem_per_job: bwa_ram
     out: [output]
 
 $namespaces:

--- a/subworkflows/rgbam_to_bwa_payload.cwl
+++ b/subworkflows/rgbam_to_bwa_payload.cwl
@@ -25,7 +25,7 @@ outputs:
           type: string
         interleaved:
           type: boolean
-    outputSource: clt_prepare_bwa_payload/bwa_payload
+    outputSource: bamtofastq/bwa_payload
 
 steps:
   samtools_head_rg:
@@ -48,19 +48,10 @@ steps:
     in:
       input_align: input_rgbam
       reference: cram_reference
+      rg_str: expression_updatergsample/rg_str
       cpu: bamtofastq_cpu
       ram: bamtofastq_ram
-    out: [output]
-
-  clt_prepare_bwa_payload:
-    run: ../tools/clt_prepare_bwa_payload.cwl
-    in:
-      reads: bamtofastq/output
-      rg_str: expression_updatergsample/rg_str
-      interleaved:
-        valueFrom: $(1 == 1)
-    out: [bwa_payload]
-
+    out: [output, bwa_payload]
 
 $namespaces:
   sbg: https://sevenbridges.com

--- a/subworkflows/rgbam_to_bwa_payload.cwl
+++ b/subworkflows/rgbam_to_bwa_payload.cwl
@@ -9,6 +9,8 @@ inputs:
   input_rgbam: File
   sample_name: string
   cram_reference: { type: 'File?', doc: "Fasta file if input is cram", secondaryFiles: [.fai] }
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
+  bamtofastq_ram: { type: 'int?', doc: "RAM in GB to allocate to bamtofastq" }
 
 outputs:
   bwa_payload:
@@ -46,6 +48,8 @@ steps:
     in:
       input_align: input_rgbam
       reference: cram_reference
+      cpu: bamtofastq_cpu
+      ram: bamtofastq_ram
     out: [output]
 
   clt_prepare_bwa_payload:

--- a/tools/biobambam_bamtofastq.cwl
+++ b/tools/biobambam_bamtofastq.cwl
@@ -10,7 +10,8 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 1000
+    ramMin: $(inputs.ram * 1000)
+    coresMin: $(inputs.cpu)
   - class: DockerRequirement
     dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev'
 baseCommand: []
@@ -27,6 +28,8 @@ inputs:
   input_align: { type: File, doc: "Input alignment file", inputBinding: { position: 1, prefix: "filename=", separate: false } }
   reference: { type: 'File?', doc: "Fasta file if input is cram", secondaryFiles: [.fai],
     inputBinding: { position: 1, prefix: "reference=", separate: false } }
+  cpu: { type: 'int?', default: 1, doc: "CPUs to allocate to this task." }
+  ram: { type: 'int?', default: 2, doc: "RAM in GBs to allocate to this task." }
 outputs:
   output: { type: 'File', outputBinding: { glob: '*.fq' } }
 

--- a/tools/biobambam_bamtofastq.cwl
+++ b/tools/biobambam_bamtofastq.cwl
@@ -26,12 +26,32 @@ arguments:
       > reads-00.fq
 inputs:
   input_align: { type: File, doc: "Input alignment file", inputBinding: { position: 1, prefix: "filename=", separate: false } }
-  reference: { type: 'File?', doc: "Fasta file if input is cram", secondaryFiles: [.fai],
-    inputBinding: { position: 1, prefix: "reference=", separate: false } }
+  reference: { type: 'File?', doc: "Fasta file if input is cram", secondaryFiles: [.fai], inputBinding: { position: 1, prefix: "reference=", separate: false } }
+  rg_str: { type: 'string?', default: "NO RG PROVIDED", doc: "Read group string taken from the input_align file. Used for bwa_payload record creation." }
   cpu: { type: 'int?', default: 1, doc: "CPUs to allocate to this task." }
   ram: { type: 'int?', default: 2, doc: "RAM in GBs to allocate to this task." }
 outputs:
   output: { type: 'File', outputBinding: { glob: '*.fq' } }
+  bwa_payload:
+    type:
+      type: record
+      fields:
+        reads_file:
+          type: File
+          outputBinding:
+            glob: '*.fq'
+        mates_file:
+          type: File?
+          outputBinding:
+            outputEval: $(null)
+        rg_str:
+          type: string
+          outputBinding:
+            outputEval: $(inputs.rg_str)
+        interleaved:
+          type: boolean
+          outputBinding:
+            outputEval: $(1 == 1)
 
 $namespaces:
   sbg: https://sevenbridges.com

--- a/tools/sentieon_bwa_sort.cwl
+++ b/tools/sentieon_bwa_sort.cwl
@@ -17,9 +17,9 @@ requirements:
 - class: InlineJavascriptRequirement
 - class: ResourceRequirement
   coresMin: |
-    $(inputs.cpu_per_job ? inputs.cpu_per_job : 32)
+    $(inputs.cpu_per_job)
   ramMin: |
-    $(inputs.mem_per_job ? inputs.mem_per_job: 32000)
+    $(inputs.mem_per_job * 1000)
 - class: DockerRequirement
   dockerPull: pgc-images.sbgenomics.com/hdchen/sentieon:202112.01_hifi
 - class: EnvVarRequirement
@@ -137,10 +137,12 @@ inputs:
   label: CPU per job
   doc: CPU per job
   type: int?
+  default: 32
 - id: mem_per_job
   label: Memory per job
-  doc: Memory per job[MB].
+  doc: Memory per job[GB].
   type: int?
+  default: 72
 outputs:
 - id: output
   type: File

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -194,10 +194,10 @@ inputs:
       to samtools split."}
   samtools_split_cores: {type: 'int?', default: 36, doc: "Minimum reserved number
       of CPU cores for samtools split."}
-  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
-  bamtofastq_ram: { type: 'int?', doc: "RAM in GB to allocate to bamtofastq" }
-  bwa_cpu: { type: 'int?', doc: "CPUs to allocate to Sentieon BWA" }
-  bwa_ram: { type: 'int?', doc: "RAM in GB to allocate to Sentieon BWA" }
+  bamtofastq_cpu: { type: 'int?', default: 3, doc: "CPUs to allocate to bamtofastq" }
+  bamtofastq_ram: { type: 'int?', default: 4, doc: "RAM in GB to allocate to bamtofastq" }
+  bwa_cpu: { type: 'int?', default: 36, doc: "CPUs to allocate to Sentieon BWA" }
+  bwa_ram: { type: 'int?', default: 72, doc: "RAM in GB to allocate to Sentieon BWA" }
 outputs:
   cram: {type: File, outputSource: sentieon_readwriter_bam_to_cram/output_reads, doc: "(Re)Aligned
       Reads File"}

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -194,6 +194,10 @@ inputs:
       to samtools split."}
   samtools_split_cores: {type: 'int?', default: 36, doc: "Minimum reserved number
       of CPU cores for samtools split."}
+  bamtofastq_cpu: { type: 'int?', doc: "CPUs to allocate to bamtofastq" }
+  bamtofastq_ram: { type: 'int?', doc: "RAM in GB to allocate to bamtofastq" }
+  bwa_cpu: { type: 'int?', doc: "CPUs to allocate to Sentieon BWA" }
+  bwa_ram: { type: 'int?', doc: "RAM in GB to allocate to Sentieon BWA" }
 outputs:
   cram: {type: File, outputSource: sentieon_readwriter_bam_to_cram/output_reads, doc: "(Re)Aligned
       Reads File"}
@@ -320,6 +324,8 @@ steps:
       input_rgbam: flatten_split_rgbams/output_files
       sample_name: biospecimen_name
       cram_reference: cram_reference
+      bamtofastq_cpu: bamtofastq_cpu
+      bamtofastq_ram: bamtofastq_ram
     out: [bwa_payload]
   prepare_pe_fq_bwa_payloads:
     run: ../tools/clt_prepare_bwa_payload.cwl
@@ -359,6 +365,8 @@ steps:
           prepare_se_fq_bwa_payloads/bwa_payload]
         linkMerge: merge_flattened
         pickValue: all_non_null
+      bwa_cpu: bwa_cpu
+      bwa_ram: bwa_ram
     out: [realgn_bam, cutadapt_stats]
   sentieon_markdups:
     run: ../tools/sentieon_dedup.cwl

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -194,8 +194,8 @@ inputs:
       to samtools split."}
   samtools_split_cores: {type: 'int?', default: 36, doc: "Minimum reserved number
       of CPU cores for samtools split."}
-  bamtofastq_cpu: { type: 'int?', default: 3, doc: "CPUs to allocate to bamtofastq" }
-  bamtofastq_ram: { type: 'int?', default: 4, doc: "RAM in GB to allocate to bamtofastq" }
+  bamtofastq_cpu: { type: 'int?', default: 1, doc: "CPUs to allocate to bamtofastq" }
+  bamtofastq_ram: { type: 'int?', default: 2, doc: "RAM in GB to allocate to bamtofastq" }
   bwa_cpu: { type: 'int?', default: 36, doc: "CPUs to allocate to Sentieon BWA" }
   bwa_ram: { type: 'int?', default: 72, doc: "RAM in GB to allocate to Sentieon BWA" }
 outputs:
@@ -316,7 +316,7 @@ steps:
   prepare_bam_bwa_payloads:
     hints:
     - class: "sbg:AWSInstanceType"
-      value: c5.9xlarge
+      value: c5.xlarge
     run: ../subworkflows/rgbam_to_bwa_payload.cwl
     when: $(inputs.input_rgbam != null)
     scatter: [input_rgbam]


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

BixOps reported two issues:
- Sentieon BWA was running out of memory on a very large input
- Heavily stacked bamtofastq jobs were using up all available disk space (1 TB) on the stacked VM

As a result, I've opened the CPU and RAM ports for the following steps:
- bamtofastq: If a job is running out of disk space, OPs can increase the CPU and/or RAM request for this job to reduce the number of concurrent scatters. Previously, jobs were only requesting 1 GB of RAM; therefore, they were able to stack up to 72 times on a c5.9xlarge instance. I've adjusted the default to be 1 CPU and 2GB RAM. Additionally, I changed the stacking instance to `c5.xlarge` (4 CPUs/8 GB RAM). As a result, stacking is limited to a max of 4. With the concurrent instances currently at 4, this means we will be able to process up to 16 read groups per pass. That's a pretty solid limit in my opinion.
- Sentieon BWA: If a job runs out of RAM, OPs can simply increase the RAM request for this job. Previously jobs were being assigned 32 CPUs and 32 GB RAM; this request would put them on a c5.9xlarge, so they actually had access to 72 GB of RAM. I've upped the default to 72 GB of RAM for clarity.

Closes https://github.com/d3b-center/bixu-tracker/issues/2328

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Stacking on the smaller instance: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/7fb7688a-f201-4d53-9612-b648af87b729/#
- [x] More ram for BWA: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/3340cbbe-531d-4d79-81b6-4248d3d4d2e6

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
