### PR TITLE
🧠  adjust t1k memory

### DIFF
--- a/tools/t1k.cwl
+++ b/tools/t1k.cwl
@@ -59,7 +59,7 @@ inputs:
   output_read_assignment: { type: 'boolean?', inputBinding: { position: 12 , prefix: "--outputReadAssignment" }, doc: "Set to output the allele assignment for each read to prefix_assign.tsv file" }
 
   threads: { type: 'int?', doc: "Num processing threads to use", default: 8, inputBinding: { position: 12, prefix: "-t" } }
-  ram: { type: 'int?', doc: "Num GB memory to make available", default: 16 }
+  ram: { type: 'int?', doc: "Num GB memory to make available", default: 32 }
 outputs:
   aligned_fasta: { type: 'File[]', outputBinding: { glob: '*_aligned_*.fa' } }
   allele_tsv: { type: File, outputBinding: { glob: '*_allele.tsv' } }

--- a/workflows/kfdrc_alignment_wf.cwl
+++ b/workflows/kfdrc_alignment_wf.cwl
@@ -392,6 +392,7 @@ inputs:
   hla_dna_gene_coords: {type: 'File?', doc: "FASTA file containing the coordinates of the HLA genes for DNA.", "sbg:suggestedValue": {
       class: File, path: 6669ac8127374715fc3ba3c2, name: hla_v3.43.0_gencode_v39_dna_coord.fa}}
   t1k_abnormal_unmap_flag: {type: 'boolean?', doc: "Set if the flag in BAM for the unmapped read-pair is nonconcordant"}
+  t1k_ram: {type: 'int?', doc: "GB of RAM to allocate to T1k." }
 outputs:
   cram: {type: File, outputSource: samtools_bam_to_cram/output, doc: "(Re)Aligned Reads File"}
   gvcf: {type: 'File[]?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated from the realigned alignment file."}
@@ -655,6 +656,7 @@ steps:
         valueFrom: $(self).t1k_hla
       skip_post_analysis:
         valueFrom: $(1 == 1)
+      ram: t1k_ram
     out: [genotype_tsv]
   samtools_bam_to_cram:
     run: ../tools/samtools_bam_to_cram.cwl

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -182,6 +182,7 @@ inputs:
   hla_dna_gene_coords: {type: 'File?', doc: "FASTA file containing the coordinates of the HLA genes for DNA.", "sbg:suggestedValue": {
       class: File, path: 6669ac8127374715fc3ba3c2, name: hla_v3.43.0_gencode_v39_dna_coord.fa}}
   t1k_abnormal_unmap_flag: {type: 'boolean?', doc: "Set if the flag in BAM for the unmapped read-pair is nonconcordant"}
+  t1k_ram: {type: 'int?', doc: "GB of RAM to allocate to T1k." }
 outputs:
   cram: {type: File, outputSource: sentieon_readwriter_bam_to_cram/output_reads, doc: "(Re)Aligned Reads File"}
   gvcf: {type: 'File?', outputSource: generate_gvcf/gvcf, doc: "Genomic VCF generated from the realigned alignment file."}
@@ -368,6 +369,7 @@ steps:
       skip_post_analysis:
         valueFrom: $(1 == 1)
       abnormal_unmap_flag: t1k_abnormal_unmap_flag
+      ram: t1k_ram
     out: [genotype_tsv]
   sentieon_readwriter_bam_to_cram:
     run: ../tools/sentieon_ReadWriter.cwl


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

T1k was failing for some samples due to running out of RAM. This PR:
- Ups the default RAM to 32 since the failure rate due to RAM was about 50% at 16 (for WGS).
- Opens the RAM port to OPs should they need to adjust it beyond 32.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
