### PR TITLE
🐎  move sort to bwa pipe

### DIFF
--- a/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -43,7 +43,6 @@ found [here](./dockers_bwagatk_alignment.md).
 | Adapter Trimming           | cutadapt                            |
 | Fastq to RG Bam            | bwa mem                             |
 | Merge RG Bams              | sambamba merge                      |
-| Sort Bam                   | sambamba sort                       |
 | Mark Duplicates            | samblaster                          |
 | BaseRecalibration          | GATK BaseRecalibrator               |
 | ApplyRecalibration         | GATK ApplyBQSR                      |

--- a/docs/dockers_bwagatk_alignment.md
+++ b/docs/dockers_bwagatk_alignment.md
@@ -27,7 +27,6 @@ picard_mergevcfs_python_renamesample.cwl|pgc-images.sbgenomics.com/d3b-bixu/pica
 picard_qualityscoredistribution_conditional.cwl|pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9R
 python_createsequencegroups.cwl|pgc-images.sbgenomics.com/d3b-bixu/python:2.7.13
 sambamba_merge_anylist.cwl|images.sbgenomics.com/bogdang/sambamba:0.6.3
-sambamba_sort.cwl|images.sbgenomics.com/bogdang/sambamba:0.6.3
 samtools_bam_to_cram.cwl|pgc-images.sbgenomics.com/d3b-bixu/samtools:1.8-dev
 samtools_idxstats_xy_ratio.cwl|pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9
 samtools_split.cwl|pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9

--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -33,7 +33,7 @@ arguments:
       ${if (inputs.mates != null) {return inputs.mates.path} else {return ""}}
       | /opt/samblaster/samblaster -i /dev/stdin -o /dev/stdout
       | /opt/sambamba_0.6.3/sambamba_v0.6.3 view -t 36 -f bam -l 0 -S /dev/stdin
-      | /opt/sambamba_0.6.3/sambamba_v0.6.3 sort -t 36 --natural-sort -m 15GiB --tmpdir ./
+      | /opt/sambamba_0.6.3/sambamba_v0.6.3 sort -t 36 -m 10G --tmpdir ./
       -o ${if (inputs.reads != null) {return inputs.reads.nameroot} else {return ""}}.unsorted.bam -l 5 /dev/stdin
 inputs:
   ref: { type: File, secondaryFiles: [.64.amb, .64.ann, .64.bwt, .64.pac, .64.sa, ^.dict, .fai], doc: "Reference fasta file with associated indexes" }

--- a/tools/sambamba_merge_anylist.cwl
+++ b/tools/sambamba_merge_anylist.cwl
@@ -48,4 +48,4 @@ inputs:
   bams: { type: 'File[]', doc: "List of BAM files" }
   base_file_name: { type: string, doc: "String to be used in naming the output bam" }
 outputs:
-  merged_bam: { type: File, outputBinding: { glob: '*.bam' }, format: BAM }
+  merged_bam: { type: File, outputBinding: { glob: '*.bam' }, secondaryFiles: [.bai], format: BAM }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

While working on the Nextflow port, I discovered an inefficiency in the BWA GATK pipeline. Currently we do:
- For each Read Group (shard): bwa mem | samblaster | sambamba sam to bam | sambamba natural sort
- sambamba merge all shards
- sambamba coordinate sort

The problem with this approach is that doing `natural sort -> merge -> coordinate sort` is unnecessary. Merge just needs files that are all sorted in _any_ way (natural, lex, coordinate) and it returns a file with the same sorting order as the input. In other words, if we give it coordinate sorted BAMs it will return a coordinate sorted BAM.

So if we change the bwa pipe to coordinate sort instead of natural sort that means we would not need to perform the coordinate sort post merge. This optimization would save us roughly an hour on a 60 GB tumor BAM file.

A note from the run: It does seem like there's some slight differences between when you natural sort -> merge -> coordinate sort versus coordinate sort -> merge, but it's just the ordering of reads at identical positions. Not a big deal/doesn't affect downstream software.

## Type of change

- [x] Optimization (non-breaking change which improves functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/4ebb34cc-d723-4908-905d-302513757eb4

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
