### PR TITLE
🐛  fix bam index capture

### DIFF
--- a/tools/bwa_mem_naive.cwl
+++ b/tools/bwa_mem_naive.cwl
@@ -44,4 +44,4 @@ inputs:
   rg: { type: string, doc: "Formatted RG header to use in the resulting BAM, check BWA for formatting guidelines (e.g. escaped tabs '\t')", inputBinding: {position: 1, shellQuote: true} }
 
 outputs:
-  output: { type: File, outputBinding: { glob: '*.bam' } }
+  output: { type: File, outputBinding: { glob: '*.bam' }, secondaryFiles: [.bai] }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Fixes an issue where BAMs would lose their BAI index when we "skip" merging.

Fixes https://d3b.atlassian.net/browse/BIXU-4016

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] "Skipping" merging: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/b6296a72-87c0-4b52-9e14-307b5d05d527/#
- [x] Merging: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/642119ea-76b4-4546-a56b-38f7529a2494/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
