### PR TITLE
🔧  check RG fields before bwa

### DIFF
--- a/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -99,7 +99,11 @@ Additionally, these files must have appropriate read group information. For
 aligned and unaligned BAM/CRAM/SAM files, we assume that information is
 contained within the file header. If your files do not have read group (`@RG`)
 header information, you **must** add that information to the file header for
-the pipeline to work!
+the pipeline to work! Make sure your the read groups have the following fields:
+- `ID`
+- `SM`
+- `LB`
+- `PL`
 
 If the user provides CRAM inputs, they must also provide the reference that was
 used to generate the CRAM file.

--- a/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -1,4 +1,4 @@
- # Kids First Data Resource Center BWA-GATK Short Reads Alignment and HaplotypeCaller Workflow
+# Kids First Data Resource Center BWA-GATK Short Reads Alignment and HaplotypeCaller Workflow
 
 <p align="center">
   <img src="./kids_first_logo.svg" alt="Kids First repository logo" width="660px" />

--- a/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_BWA_GATK_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -1,4 +1,4 @@
-# Kids First Data Resource Center BWA-GATK Short Reads Alignment and HaplotypeCaller Workflow
+ # Kids First Data Resource Center BWA-GATK Short Reads Alignment and HaplotypeCaller Workflow
 
 <p align="center">
   <img src="./kids_first_logo.svg" alt="Kids First repository logo" width="660px" />
@@ -99,7 +99,7 @@ Additionally, these files must have appropriate read group information. For
 aligned and unaligned BAM/CRAM/SAM files, we assume that information is
 contained within the file header. If your files do not have read group (`@RG`)
 header information, you **must** add that information to the file header for
-the pipeline to work! Make sure your the read groups have the following fields:
+the pipeline to work! Make sure the read groups have the following fields:
 - `ID`
 - `SM`
 - `LB`

--- a/tools/expression_preparerg.cwl
+++ b/tools/expression_preparerg.cwl
@@ -11,14 +11,23 @@ inputs:
 outputs:
   rg_str: { type: string }
 
-expression:
-  "${
-      if (inputs.rg == null) {return {rg_str: null}};
-      var arr = inputs.rg.contents.split('\\n')[0].split('\\t');
-      for (var i=1; i<arr.length; i++){
-        if (arr[i].startsWith('SM')){
-          arr[i] = 'SM:' + inputs.sample;
-        }
+expression: |
+  ${
+      if (inputs.rg == null) { return { rg_str: null }}
+      var required_fields = ["ID", "SM", "LB", "PL"]
+      var rg_fields = inputs.rg.contents.trim().split('\t')
+      for (var index in rg_fields) {
+          var field = rg_fields[index]
+          if (field.startsWith("SM:")) {
+              rg_fields[index] = 'SM:' + inputs.sample
+          }
+          var key = field.split(":")[0]
+          if (required_fields.indexOf(key) > -1) {
+              required_fields.splice(required_fields.indexOf(key), 1)
+          }
       }
-      return {rg_str: arr.join('\\\\t')};
-    }"
+      if (required_fields.length > 0) {
+          throw new Error("Missing Required RG Fields: " + required_fields.join(','))
+      }
+      return {rg_str: rg_fields.join('\\t')}
+  }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Adds a quick check for required RG fields before BWA. The RG fields are not required until GATK processes down the line. Throwing an earlier error saves some time/headache.

Stems from this discussion: https://github.com/kids-first/kf-alignment-workflow/issues/158
Tracked https://d3b.atlassian.net/browse/BIXU-4485

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Input BAM without RG PL (erroring as expected): https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/b1e4d7e8-bc61-43fd-ade6-2bfb21556bb6/#
- [x] Proper input BAM: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/d06c9b03-1460-4cb8-b05b-543f0a569bfa/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
